### PR TITLE
maintain executable permissions when copying server during build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,9 +24,9 @@ task :build => :qmake do
   FileUtils.mkdir("bin") unless File.directory?("bin")
 
   if File.exist?("src/webkit_server.app")
-    FileUtils.cp("src/webkit_server.app/Contents/MacOS/webkit_server", "bin")
+    FileUtils.cp("src/webkit_server.app/Contents/MacOS/webkit_server", "bin", :preserve => true)
   else
-    FileUtils.cp("src/webkit_server", "bin")
+    FileUtils.cp("src/webkit_server", "bin", :preserve => true)
   end
 end
 


### PR DESCRIPTION
otherwise the server cannot be run because it is not an executable file. I am on Ubuntu 10.10.
