### PR TITLE
Protect against qmake being named with version.

### DIFF
--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -4,7 +4,9 @@ module CapybaraWebkitBuilder
   extend self
 
   def makefile
-    system("qmake -spec macx-g++")
+    qmake_binaries = ['qmake', 'qmake-qt4']
+    qmake = qmake_binaries.detect { |qmake| system("which #{qmake}") }
+    system("#{qmake} -spec macx-g++")
   end
 
   def qmake


### PR DESCRIPTION
Reproducible on Fedora Core 13, qmake for qt4 is named qmake-qt4.
