### PR TITLE
Simplify building on Mac OS X

### DIFF
--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -15,12 +15,7 @@ module CapybaraWebkitBuilder
     system("make") or return false
 
     FileUtils.mkdir("bin") unless File.directory?("bin")
-
-    if File.exist?("src/webkit_server.app")
-      FileUtils.cp("src/webkit_server.app/Contents/MacOS/webkit_server", "bin", :preserve => true)
-    else
-      FileUtils.cp("src/webkit_server", "bin", :preserve => true)
-    end
+    FileUtils.cp("src/webkit_server", "bin", :preserve => true)
   end
 
   def build_all

--- a/src/webkit_server.pro
+++ b/src/webkit_server.pro
@@ -6,4 +6,5 @@ SOURCES = main.cpp WebPage.cpp Server.cpp Connection.cpp Command.cpp Visit.cpp F
 RESOURCES = webkit_server.qrc
 QT += network webkit
 CONFIG += console
+CONFIG -= app_bundle
 


### PR DESCRIPTION
This change forces console app building of the webkit_server on Mac OS X (`CONFIG += console` isn't quite enough to trigger it), so there's no need to extract the binary from an app bundle anymore. I've been using this technique in my own WebKit widget-based project with no problems so far.
