### PR TITLE
Fix issue #34: Couldn't install capybara-webkit: g++: error: unrecognized option '-h'

### DIFF
--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -4,7 +4,12 @@ module CapybaraWebkitBuilder
   extend self
 
   def makefile
-    system("qmake -spec macx-g++")
+    case RUBY_PLATFORM
+    when /linux/
+      system("qmake -spec linux-g++")
+    else
+      system("qmake -spec macx-g++")
+    end
   end
 
   def qmake
@@ -15,8 +20,7 @@ module CapybaraWebkitBuilder
     system("make") or return false
 
     FileUtils.mkdir("bin") unless File.directory?("bin")
-
-    if File.exist?("src/webkit_server.app")
+    if !(RUBY_PLATFORM =~ /linux/) && File.exist?("src/webkit_server.app")
       FileUtils.cp("src/webkit_server.app/Contents/MacOS/webkit_server", "bin", :preserve => true)
     else
       FileUtils.cp("src/webkit_server", "bin", :preserve => true)


### PR DESCRIPTION
I tried to install `capybara-webkit` and get an error: 

```
$ LANG=en_EN gem install capybara-webkit
    Building native extensions.  This could take a while...
    ERROR:  Error installing capybara-webkit:
        ERROR: Failed to build gem native extension.

    /home/petrushka/.rvm/rubies/ruby-1.8.7-p302/bin/ruby extconf.rb
    cd src/ && /usr/bin/qmake /home/petrushka/.rvm/gems/ruby-1.8.7-p302/gems/capybara-webkit-0.2.0/src/webkit_server.pro -spec /usr/share/qt/mkspecs/macx-g++ -o Makefile.webkit_server
    cd src/ && make -f Makefile.webkit_server 
    make[1]: Entering directory `/home/petrushka/.rvm/gems/ruby-1.8.7-p302/gems/capybara-webkit-0.2.0/src'
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o main.o main.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o WebPage.o WebPage.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o Server.o Server.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o Connection.o Connection.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o Command.o Command.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o Visit.o Visit.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o Find.o Find.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o Reset.o Reset.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o Node.o Node.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o JavascriptInvocation.o JavascriptInvocation.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o Url.o Url.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o Source.o Source.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o Evaluate.o Evaluate.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o Execute.o Execute.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o FrameFocus.o FrameFocus.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ WebPage.h -o moc_WebPage.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_WebPage.o moc_WebPage.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ Server.h -o moc_Server.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_Server.o moc_Server.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ Connection.h -o moc_Connection.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_Connection.o moc_Connection.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ Command.h -o moc_Command.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_Command.o moc_Command.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ Visit.h -o moc_Visit.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_Visit.o moc_Visit.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ Find.h -o moc_Find.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_Find.o moc_Find.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ Reset.h -o moc_Reset.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_Reset.o moc_Reset.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ Node.h -o moc_Node.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_Node.o moc_Node.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ JavascriptInvocation.h -o moc_JavascriptInvocation.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_JavascriptInvocation.o moc_JavascriptInvocation.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ Url.h -o moc_Url.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_Url.o moc_Url.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ Source.h -o moc_Source.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_Source.o moc_Source.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ Evaluate.h -o moc_Evaluate.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_Evaluate.o moc_Evaluate.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ Execute.h -o moc_Execute.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_Execute.o moc_Execute.cpp
    /usr/bin/moc -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -D__APPLE__ -D__GNUC__ FrameFocus.h -o moc_FrameFocus.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o moc_FrameFocus.o moc_FrameFocus.cpp
    /usr/bin/rcc -name webkit_server webkit_server.qrc -o qrc_webkit_server.cpp
    g++ -c -pipe -O2 -Wall -W -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/macx-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtWebKit -I/usr/include -I. -o qrc_webkit_server.o qrc_webkit_server.cpp
    g++ -headerpad_max_install_names -o webkit_server.app/Contents/MacOS/webkit_server main.o WebPage.o Server.o Connection.o Command.o Visit.o Find.o Reset.o Node.o JavascriptInvocation.o Url.o Source.o Evaluate.o Execute.o FrameFocus.o moc_WebPage.o moc_Server.o moc_Connection.o moc_Command.o moc_Visit.o moc_Find.o moc_Reset.o moc_Node.o moc_JavascriptInvocation.o moc_Url.o moc_Source.o moc_Evaluate.o moc_Execute.o moc_FrameFocus.o qrc_webkit_server.o    -L/usr/lib -lQtWebKit -lQtGui -lQtNetwork -lQtCore 
    g++: error: unrecognized option '-h'
    make[1]: *** [webkit_server.app/Contents/MacOS/webkit_server] Error 1
    make[1]: Leaving directory `/home/petrushka/.rvm/gems/ruby-1.8.7-p302/gems/capybara-webkit-0.2.0/src'
    make: *** [sub-src-webkit_server-pro-make_default-ordered] Error 2

    make
    cd src/ && make -f Makefile.webkit_server 
    make[1]: Entering directory `/home/petrushka/.rvm/gems/ruby-1.8.7-p302/gems/capybara-webkit-0.2.0/src'
    g++ -headerpad_max_install_names -o webkit_server.app/Contents/MacOS/webkit_server main.o WebPage.o Server.o Connection.o Command.o Visit.o Find.o Reset.o Node.o JavascriptInvocation.o Url.o Source.o Evaluate.o Execute.o FrameFocus.o moc_WebPage.o moc_Server.o moc_Connection.o moc_Command.o moc_Visit.o moc_Find.o moc_Reset.o moc_Node.o moc_JavascriptInvocation.o moc_Url.o moc_Source.o moc_Evaluate.o moc_Execute.o moc_FrameFocus.o qrc_webkit_server.o    -L/usr/lib -lQtWebKit -lQtGui -lQtNetwork -lQtCore 
    g++: error: unrecognized option '-h'
    make[1]: *** [webkit_server.app/Contents/MacOS/webkit_server] Error 1
    make[1]: Leaving directory `/home/petrushka/.rvm/gems/ruby-1.8.7-p302/gems/capybara-webkit-0.2.0/src'
    make: *** [sub-src-webkit_server-pro-make_default-ordered] Error 2


    Gem files will remain installed in /home/petrushka/.rvm/gems/ruby-1.8.7-p302/gems/capybara-webkit-0.2.0 for inspection.
    Results logged to /home/petrushka/.rvm/gems/ruby-1.8.7-p302/gems/capybara-webkit-0.2.0/gem_make.out
```

Same results on 1.8.7 and 1.9.2
Arch linux, qt installed

g++ vesrion:

```
  $ LANG=en_EN g++ -v
  Using built-in specs.
  COLLECT_GCC=g++
  COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-unknown-linux-gnu/4.6.0/lto-wrapper
  Target: x86_64-unknown-linux-gnu
  Configured with: /build/src/gcc-4.6-20110415/configure --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://bugs.archlinux.org/ --enable-languages=c,c++,ada,fortran,go,lto,objc,obj-c++ --enable-shared --enable-threads=posix --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-clocale=gnu --enable-gnu-unique-object --enable-linker-build-id --with-ppl --enable-cloog-backend=isl --enable-lto --enable-gold --enable-ld=default --enable-plugin --with-plugin-ld=ld.gold --disable-multilib --disable-libstdcxx-pch --enable-checking=release
  Thread model: posix
  gcc version 4.6.0 20110415 (prerelease) (GCC) 
```
