### PR TITLE
More exception cases for attempt_connect race condition

### DIFF
--- a/lib/capybara/driver/webkit/browser.rb
+++ b/lib/capybara/driver/webkit/browser.rb
@@ -77,7 +77,7 @@ class Capybara::Driver::Webkit
 
     def attempt_connect
       @socket = @socket_class.open("localhost", 9200)
-    rescue Errno::ECONNREFUSED
+    rescue Errno::ECONNREFUSED, Errno::EAFNOSUPPORT, Errno::EACCES
     end
 
     def check


### PR DESCRIPTION
In attempt_connect, Errno::ECONNREFUSED is handled silently but I've run into additional exceptions that are temporary that should also be handled silently. Namely Errno::EAFNOSUPPORT and Errno::EACCES. Errno::EAFNOSUPPORT can be raised when the Xvfb process isn't finished booting yet on Gentoo thanks to a race condition with the headless gem. I haven't been able to consistently recreate Errno::EACCES.
