### PR TITLE
Forcing retunrned string as UTF-8

### DIFF
--- a/lib/capybara/driver/webkit/browser.rb
+++ b/lib/capybara/driver/webkit/browser.rb
@@ -90,7 +90,9 @@ class Capybara::Driver::Webkit
 
     def read_response
       response_length = @socket.gets.to_i
-      @socket.read(response_length)
+      s = @socket.read(response_length)
+      s.force_encoding("UTF-8")
+      s
     end
   end
 end


### PR DESCRIPTION
This fixes issue#55. I think it is safe to assume webkit_server to return UTF-8 string.
I tried to set the socket using IO#set_encoding but it doesn't work that way.
