### PR TITLE
fixed memory leak, memory allocated by new[] was freed by delete instead 

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -55,7 +55,7 @@ void Connection::readDataBlock() {
   buffer[m_expectingDataSize] = 0;
   processNext(buffer);
   m_expectingDataSize = -1;
-  delete buffer;
+  delete[] buffer;
 }
 
 void Connection::processNext(const char *data) {


### PR DESCRIPTION
fixed memory leak, memory allocated by new[] was freed by delete instead of delete[]
