### PR TITLE
force args to use to_s

### DIFF
--- a/lib/capybara/driver/webkit/browser.rb
+++ b/lib/capybara/driver/webkit/browser.rb
@@ -45,7 +45,7 @@ class Capybara::Driver::Webkit
       @socket.puts args.size
       args.each do |arg|
         @socket.puts arg.to_s.bytesize
-        @socket.print arg
+        @socket.print arg.to_s
       end
       check
       read_response

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -311,6 +311,12 @@ describe Capybara::Driver::Webkit do
       input.value.should == "newvalue"
     end
 
+    it "sets an input's nil value" do
+      input = subject.find("//input").first
+      input.set(nil)
+      input.value.should == ""
+    end
+
     it "sets a select's value" do
       select = subject.find("//select").first
       select.set("Monkey")


### PR DESCRIPTION
on ree 1.8.7, print method convert nil to "nil". but nil.to_s is "".
see https://gist.github.com/1046896
