### PR TITLE
Simple change to error output, would have saved me time debugging.

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -95,7 +95,7 @@ void Connection::startCommand() {
               SLOT(finishCommand(Response *)));
       m_command->start(m_arguments);
     } else {
-      QString failure = QString("Unknown command: ") +  m_commandName + "\n";
+      QString failure = QString("[Capybara WebKit] Unknown command: ") +  m_commandName + "\n";
       writeResponse(new Response(false, failure));
     }
     m_commandName = QString();


### PR DESCRIPTION
Improve the failure message, make it senseful when trying to discover what a service is from telnet, and a listen port.

The problem in my case, was that the Tire gem, for ElasticSearch is able to connect to something listening on the default ElasticSearch port (9200), and sends an HTTP request, the error response is non-sensical, and doesn't help you figure out what's going on.

Unfortunately, normally when the test-run is finished, the capybara webkit server has gone away, leaving no trace of where the error came from.
