### PR TITLE
configurable port

### DIFF
--- a/lib/capybara/driver/webkit.rb
+++ b/lib/capybara/driver/webkit.rb
@@ -13,7 +13,7 @@ class Capybara::Driver::Webkit
     @options = options
     @rack_server = Capybara::Server.new(@app)
     @rack_server.boot if Capybara.run_server
-    @browser = options[:browser] || Browser.new
+    @browser = options[:browser] || Browser.new({:port => options[:port]})
   end
 
   def current_url

--- a/lib/capybara/driver/webkit/browser.rb
+++ b/lib/capybara/driver/webkit/browser.rb
@@ -6,6 +6,7 @@ class Capybara::Driver::Webkit
   class Browser
     def initialize(options = {})
       @socket_class = options[:socket_class] || TCPSocket
+      @port = options.fetch(:port) { 8200 }
       start_server
       connect
     end
@@ -68,7 +69,7 @@ class Capybara::Driver::Webkit
 
     def start_server
       server_path = File.expand_path("../../../../../bin/webkit_server", __FILE__)
-      @pid = fork { exec(server_path) }
+      @pid = fork { exec(server_path+" #{@port}") }
       at_exit { Process.kill("INT", @pid) }
     end
 
@@ -80,7 +81,7 @@ class Capybara::Driver::Webkit
     end
 
     def attempt_connect
-      @socket = @socket_class.open("localhost", 8200)
+      @socket = @socket_class.open("localhost", @port)
     rescue Errno::ECONNREFUSED
     end
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -9,9 +9,9 @@ Server::Server(QObject *parent) : QObject(parent) {
   m_page = new WebPage(this);
 }
 
-bool Server::start() {
+bool Server::start(int port) {
   connect(m_tcp_server, SIGNAL(newConnection()), this, SLOT(handleConnection()));
-  return m_tcp_server->listen(QHostAddress::Any, 8200);
+  return m_tcp_server->listen(QHostAddress::Any, port);
 }
 
 void Server::handleConnection() {

--- a/src/Server.h
+++ b/src/Server.h
@@ -8,7 +8,7 @@ class Server : public QObject {
 
   public:
     Server(QObject *parent = 0);
-    bool start();
+    bool start(int port);
 
   public slots:
     void handleConnection();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 int main(int argc, char **argv) {
+  int port = 8200;
   QApplication app(argc, argv);
   app.setApplicationName("capybara-webkit");
   app.setOrganizationName("thoughtbot, inc");
@@ -10,7 +11,11 @@ int main(int argc, char **argv) {
 
   Server server;
 
-  if (server.start()) {
+  if (argc > 1) {
+    port = atoi(argv[1]);
+  }
+
+  if (server.start(port)) {
     return app.exec();
   } else {
     std::cerr << "Couldn't start server" << std::endl;


### PR DESCRIPTION
Hey all, I've added the ability to configure the port by registering a new driver:

Capybara.register_driver :webkit do |app|
  Capybara::Driver::Webkit.new(app, :port => 9989)
end

It passes the port as a command line argument to the webkit server when it's booted. This should get us started towards using something like parallel_tests with webkit.

I would really appreciate a code review, since my cpp skills are pretty rusty. Also, I didn't see an appropriate way to test the code, so there is also no test. However you can change the port in the tests and they still pass.

Thanks for the great gem,
xoxo @ngauthier

p.s. this references Issue #76 https://github.com/thoughtbot/capybara-webkit/pull/76
