### PR TITLE
Don't strip unless the result if non-nil.

### DIFF
--- a/lib/capybara/driver/webkit.rb
+++ b/lib/capybara/driver/webkit.rb
@@ -3,7 +3,10 @@ require "capybara/driver/webkit/node"
 require "capybara/driver/webkit/browser"
 
 class Capybara::Driver::Webkit
-  class WebkitError < StandardError
+  class WebkitInvalidResponseError < StandardError
+  end
+
+  class WebkitNoResponseError < StandardError
   end
 
   attr_reader :browser

--- a/lib/capybara/driver/webkit/browser.rb
+++ b/lib/capybara/driver/webkit/browser.rb
@@ -110,11 +110,16 @@ class Capybara::Driver::Webkit
     end
 
     def check
-      result = @socket.gets.strip
+      result = @socket.gets
+      result.strip! if result
 
-      unless result == 'ok'
-        raise WebkitError, read_response
+      if result.nil?
+        raise WebkitNoResponseError, "No response received from the server."
+      elsif result != 'ok' 
+        raise WebkitInvalidResponseError, read_response
       end
+
+      result
     end
 
     def read_response


### PR DESCRIPTION
Don't strip the result if it comes back as nil, as it will throw an exception before capybara-webkit can throw a WebkitError.
