### PR TITLE
Forward webkit_server's stdout to Ruby's stdout

### DIFF
--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'stringio'
 require 'capybara/driver/webkit/browser'
 
 describe Capybara::Driver::Webkit::Browser do
@@ -21,6 +22,14 @@ describe Capybara::Driver::Webkit::Browser do
       new_browser = Capybara::Driver::Webkit::Browser.new
       new_browser.server_port.should_not == browser.server_port
     end
+  end
+  
+  it 'forwards stdout to the given IO object' do
+    io = StringIO.new
+    new_browser = Capybara::Driver::Webkit::Browser.new(:stdout => io)
+    new_browser.execute_script('console.log("hello world")')
+    sleep(0.5)
+    io.string.should == "hello world\n"
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ end
 require File.join(spec_dir,"spec_helper")
 
 require 'capybara/driver/webkit/browser'
-$webkit_browser = Capybara::Driver::Webkit::Browser.new(:socket_class => TCPSocket)
+$webkit_browser = Capybara::Driver::Webkit::Browser.new(:socket_class => TCPSocket, :stdout => nil)
 
 Capybara.register_driver :reusable_webkit do |app|
   Capybara::Driver::Webkit.new(app, :browser => $webkit_browser)


### PR DESCRIPTION
This allows console.log() messages to be visible, and prevents large numbers of console.log() calls from filling up webkit_server's pipe which would block the process. It also fixes issue #118: https://github.com/thoughtbot/capybara-webkit/issues/118
