### PR TITLE
Use only IO.popen for spawning webkit_server

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,18 @@
 #include "Server.h"
 #include <QtGui>
 #include <iostream>
+#ifdef Q_OS_UNIX
+  #include <unistd.h>
+#endif
 
 int main(int argc, char **argv) {
+#ifdef Q_OS_UNIX
+  if (setpgid(0, 0) < 0) {
+    std::cerr << "Unable to set new process group." << std::endl;
+    return 1;
+  }
+#endif
+
   QApplication app(argc, argv);
   app.setApplicationName("capybara-webkit");
   app.setOrganizationName("thoughtbot, inc");


### PR DESCRIPTION
Use only IO.popen for spawning webkit_server, it already closes unnecessary file descriptors.
Fixes issue #137.
