### PR TITLE
Allow ignoring of SSL certificate warnings

### DIFF
--- a/src/NetworkAccessManager.cpp
+++ b/src/NetworkAccessManager.cpp
@@ -8,12 +8,29 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent):QNetworkAccessManage
 
 QNetworkReply* NetworkAccessManager::createRequest(QNetworkAccessManager::Operation oparation, const QNetworkRequest &request, QIODevice * outgoingData = 0) {
   QNetworkRequest new_request(request);
+
+  // emulate Firefox, allowing to disable certificate
+  // verification using an environment variable
+  if (!strcmp(getenv("IGNORECERT"), "1")) {
+    QSslConfiguration config = request.sslConfiguration();
+    config.setPeerVerifyMode(QSslSocket::VerifyNone);
+    config.setProtocol(QSsl::TlsV1);
+    QNetworkRequest new_request(request);
+    new_request.setSslConfiguration(config);
+  }
+
   QHashIterator<QString, QString> item(m_headers);
   while (item.hasNext()) {
       item.next();
       new_request.setRawHeader(item.key().toAscii(), item.value().toAscii());
   }
-  return QNetworkAccessManager::createRequest(oparation, new_request, outgoingData);
+  QNetworkReply *reply = QNetworkAccessManager::createRequest(oparation, new_request, outgoingData);
+
+  // not sure 100% if this is needed, but just in case
+  if (!strcmp(getenv("IGNORECERT"), "1"))
+    reply->ignoreSslErrors();
+
+  return reply;
 };
 
 void NetworkAccessManager::addHeader(QString key, QString value) {


### PR DESCRIPTION
This variable is used by people together with Firefox/webdriver to ignore warnings when using self signed certificates.

This workaround should fix the issue #16 for people doing remote testing with a http to https redirect.

I dont have a test yet. I am not sure ow this can be tested with a rack app, as the bugs shows up when using Capybara.app_host with remote testing. Ideas for a test welcomed.

Also I havent documented it yet, but if the README.md is ok, I can add it.
