### PR TITLE
Old version of Capybara locked

### DIFF
--- a/capybara-webkit.gemspec
+++ b/capybara-webkit.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.rubygems_version = "1.3.5"
   s.summary = "Headless Webkit driver for Capybara"
-  s.add_runtime_dependency "capybara", ">= 1.1.1"
+  s.add_runtime_dependency "capybara", "~> 1.0"
   s.extensions = "extconf.rb"
 end
 


### PR DESCRIPTION
With the version of capybara locked to 0.4.1 you get an error as the latest cucumber-rails (that plays nicely with Rails 3.1) requires a newer version:

Bundler could not find compatible versions for gem "capybara":
  In Gemfile:
    capybara-webkit depends on
      capybara (~> 0.4.1)

```
cucumber-rails (>= 1.0.4) depends on
  capybara (1.1.1)
```
