### PR TITLE
require "capybara/webkit"

### DIFF
--- a/lib/capybara-webkit.rb
+++ b/lib/capybara-webkit.rb
@@ -1,11 +1,1 @@
-require "capybara"
-require "capybara/driver/webkit"
-
-Capybara.register_driver :webkit do |app|
-  Capybara::Driver::Webkit.new(app)
-end
-
-Capybara.register_driver :webkit_debug do |app|
-  browser = Capybara::Driver::Webkit::Browser.new(:socket_class => Capybara::Driver::Webkit::SocketDebugger)
-  Capybara::Driver::Webkit.new(app, :browser => browser)
-end
+require "capybara/webkit"

--- a/lib/capybara/webkit.rb
+++ b/lib/capybara/webkit.rb
@@ -1,0 +1,11 @@
+require "capybara"
+require "capybara/driver/webkit"
+
+Capybara.register_driver :webkit do |app|
+  Capybara::Driver::Webkit.new(app)
+end
+
+Capybara.register_driver :webkit_debug do |app|
+  browser = Capybara::Driver::Webkit::Browser.new(:socket_class => Capybara::Driver::Webkit::SocketDebugger)
+  Capybara::Driver::Webkit.new(app, :browser => browser)
+end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -1,7 +1,7 @@
 # -*- encoding: UTF-8 -*-
 
 require 'spec_helper'
-require 'capybara-webkit'
+require 'capybara/webkit'
 
 describe Capybara::Session do
   subject { Capybara::Session.new(:reusable_webkit, @app) }


### PR DESCRIPTION
When a gem is named "something-something" I expect to require it as "something/something", not "something-something" :)

Cheers
