### PR TITLE
Use textContent to retrieve text of nodes.

### DIFF
--- a/src/WebPage.cpp
+++ b/src/WebPage.cpp
@@ -20,7 +20,6 @@ WebPage::WebPage(QObject *parent) : QWebPage(parent) {
           this, SLOT(frameCreated(QWebFrame *)));
   connect(this, SIGNAL(unsupportedContent(QNetworkReply*)),
       this, SLOT(handleUnsupportedContent(QNetworkReply*)));
-  this->setViewportSize(QSize(1680, 1050));
 }
 
 void WebPage::setCustomNetworkAccessManager() {

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -32,13 +32,7 @@ Capybara = {
   },
 
   text: function (index) {
-    var node = this.nodes[index];
-    var type = (node.type || node.tagName).toLowerCase();
-    if (type == "textarea") {
-      return node.innerHTML;
-    } else {
-      return node.innerText;
-    }
+    return this.nodes[index].textContent;
   },
 
   attribute: function (index, name) {


### PR DESCRIPTION
I ran into issues checking for text within a node, similar to #195. I'm setting the width and height on `html` and `body` to 100% and hiding overflow on `body`. The text was within an absolute positioned container spanning the height of the page. When overflow was set to `auto` or `hidden` on the container the text would no longer be found.

I was unable to recreate the issue even with the full HTML and CSS from my application. To avoid spending all weekend trying to recreate it in a test case I verified the `textContent` change works by removing the [line in the original fix](https://github.com/thoughtbot/capybara-webkit/commit/8d2251de38fd2a046ef085e0285b7cbf289369d6#L1R23) and by using it in my application.

There are some differences between `innerText` and `textContent`, best explained by [MDN](https://developer.mozilla.org/En/DOM/Node.textContent):

<blockquote>
  <p>Internet Explorer introduced element.innerText. The intention is pretty much the same with a couple of differences:</p>

  <ul>
    <li>Note that while textContent gets the content of all elements, including script and style elements, the mostly equivalent IE-specific property, innerText, does not.</li>
    <li>innerText is also aware of style and will not return the text of hidden elements, whereas textContent will.</li>
    <li>As innerText is aware of CSS styling, it will trigger a reflow, whereas textContent will not.</li>
  </ul>
</blockquote>


The one difference I can see possibly being an issue is the fact that `textContent` will return the text of hidden elements. There's currently no test for it though, so perhaps it is not an issue.
