### PR TITLE
New option to ignore ssl errors

### DIFF
--- a/lib/capybara/webkit.rb
+++ b/lib/capybara/webkit.rb
@@ -5,6 +5,11 @@ Capybara.register_driver :webkit do |app|
   Capybara::Driver::Webkit.new(app)
 end
 
+Capybara.register_driver :webkit_ignore_ssl do |app|
+  browser = Capybara::Driver::Webkit::Browser.new(:ignore_ssl_errors => true)
+  Capybara::Driver::Webkit.new(app, :browser => browser)
+end
+
 Capybara.register_driver :webkit_debug do |app|
   browser = Capybara::Driver::Webkit::Browser.new(:socket_class => Capybara::Driver::Webkit::SocketDebugger)
   Capybara::Driver::Webkit.new(app, :browser => browser)


### PR DESCRIPTION
Hi, I think this is a clean way to allow ignore_ssl_option to be passed to the Browser.
