### PR TITLE
Add qmake-qt47 for CentOS 5

### DIFF
--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -9,7 +9,7 @@ module CapybaraWebkitBuilder
   end
 
   def makefile
-    qmake_binaries = ['qmake', 'qmake-qt4']
+    qmake_binaries = ['qmake', 'qmake-qt4', 'qmake-qt47']
     qmake = qmake_binaries.detect { |qmake| system("which #{qmake}") }
     case RUBY_PLATFORM
     when /linux/


### PR DESCRIPTION
That's what the binary is called there for some reason.
