### PR TITLE
Fix for issue #208

### DIFF
--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -1,4 +1,5 @@
 require "fileutils"
+require "rbconfig"
 
 module CapybaraWebkitBuilder
   extend self
@@ -11,7 +12,7 @@ module CapybaraWebkitBuilder
   def makefile
     qmake_binaries = ['qmake', 'qmake-qt4']
     qmake = qmake_binaries.detect { |qmake| system("which #{qmake}") }
-    case RUBY_PLATFORM
+    case Config::CONFIG['host_os']
     when /linux/
       system("#{qmake} -spec linux-g++")
     when /freebsd/


### PR DESCRIPTION
This fixes a problem with building when using jruby, because RUBY_PLATFORM is 'java'. This causes the case statement to always assume the OS is OSX, which obviously fails on anything that isn't OSX.

I'm not sure what the best process is for fixing problems with build scripts; I'm not aware of any way to test it other than simply trying the build on every supported platform. I've only been able to try it on linux ree, linux jruby, and OSX 1.9.2.
