### PR TITLE
visit no longer tries to fix invalid URLs

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -223,9 +223,9 @@ describe Capybara::Driver::Webkit do
       subject.current_url.should == "http://127.0.0.1:#{port}/hello/world?success=true"
     end
 
-    it "escapes URLs" do
-      subject.visit("/hello there")
-      subject.current_url.should =~ /hello%20there/
+    it "does not double-encode URLs" do
+      subject.visit("/hello/world?success=%25true")
+      subject.current_url.should =~ /success=\%25true/
     end
 
     it "visits a page with an anchor" do

--- a/src/Visit.cpp
+++ b/src/Visit.cpp
@@ -7,7 +7,7 @@ Visit::Visit(WebPage *page, QObject *parent) : Command(page, parent) {
 }
 
 void Visit::start(QStringList &arguments) {
-  QUrl requestedUrl = QUrl(arguments[0]);
+  QUrl requestedUrl = QUrl::fromEncoded(arguments[0].toUtf8(), QUrl::StrictMode);
   page()->currentFrame()->load(QUrl(requestedUrl));
 }
 


### PR DESCRIPTION
This change allows perfectly valid, encoded urls to be visited.  (Before they would be double-encoded)  

As a consequence of this change, unencoded urls (that need encoding) will not work when visited.

From the capybara list: http://groups.google.com/group/ruby-capybara/browse_thread/thread/9016972307f0427c/ffb27820a0fe4e24?lnk=gst&q=webkit#ffb27820a0fe4e24
