### PR TITLE
add imagemagick dependency to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,14 @@
 We love pull requests. Here's a quick guide:
 
+Dependencies
+
+Some of the tests depend on the `identify` command that comes with Imagemagick.
+Imagemagick can be installed via [homebrew](http://mxcl.github.com/homebrew/).
+
+    brew install imagemagick
+
+Contributing
+
 1. Fork the repo.
 
 2. Run the tests. We only take pull requests with passing tests, and it's great


### PR DESCRIPTION
Several tests in driver_rendering_spec.rb require the identify command
that is part of Imagemagick. Without it they fail with output similar to
the following.

```
MiniMagick::Error:
   Command ("identify -ping
/var/folders/y3/vfvjgwm91f1fmt2syh21czx40000gn/T/mini_magick20120115-49056-pwh5nl-0.png")
failed: {:output=>"sh: identify: command not found\n", :status_code=>127}
```
