### PR TITLE
remove stdout message from driver_spec

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -324,7 +324,6 @@ describe Capybara::Driver::Webkit do
 
     before(:all) do
       @app = lambda do |env|
-        puts "running"
         body = <<-HTML
           <html>
             <head>


### PR DESCRIPTION
The console message tests were printing "running" to stdout during the
tests, which broke up the test output. Debugging print statements can
always be put in temporarily if needed without checking them in.
