### PR TITLE
Raise error when the driver tries to click an invisilbe element, like Selenium does

### DIFF
--- a/lib/capybara/driver/webkit/node.rb
+++ b/lib/capybara/driver/webkit/node.rb
@@ -37,6 +37,7 @@ class Capybara::Driver::Webkit
     end
 
     def select_option
+      check_visibility(self)
       invoke "selectOption"
     end
 
@@ -50,14 +51,13 @@ class Capybara::Driver::Webkit
     end
 
     def click
-      if visible?
-        invoke "click"
-      else
-        raise ElementNotDisplayedError, "This element is not visible so it may not be interacted with"
-      end
+      check_visibility(self)
+      invoke "click"
     end
 
     def drag_to(element)
+      check_visibility(self)
+      check_visibility(element)
       invoke 'dragTo', element.native
     end
 
@@ -125,6 +125,10 @@ class Capybara::Driver::Webkit
 
     def multiple_select?
       self.tag_name == "select" && self["multiple"] == "multiple"
+    end
+
+    def check_visibility(element)
+      raise(ElementNotDisplayedError, "This element is not visible so it may not be interacted with") unless element.visible?
     end
   end
 end

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -619,10 +619,13 @@ describe Capybara::Driver::Webkit do
             <div id="change">Change me</div>
             <div id="mouseup">Push me</div>
             <div id="mousedown">Release me</div>
+            <div id="invisible-mouseup" style="display:none;">You can't push me</div>
+            <div id="invisible-mousedown" style="display:none;">You can't release me</div>
             <form action="/" method="GET">
               <select id="change_select" name="change_select">
                 <option value="1" id="option-1" selected="selected">one</option>
                 <option value="2" id="option-2">two</option>
+                <option value="2" id="invisible-option" style="display:none;">three</option>
               </select>
             </form>
             <script type="text/javascript">
@@ -663,12 +666,6 @@ describe Capybara::Driver::Webkit do
       subject.find("//*[@class='triggered']").should_not be_empty
     end
 
-    it "raises error when it tries to click an invisible element" do
-      expect {
-        subject.find("//*[@id='hidden']").first.click
-      }.to raise_error(Capybara::Driver::Webkit::Node::ElementNotDisplayedError)
-    end
-
     it "fires a non-mouse event" do
       subject.find("//*[@id='change']").first.trigger("change")
       subject.find("//*[@class='triggered']").should_not be_empty
@@ -690,6 +687,39 @@ describe Capybara::Driver::Webkit do
       draggable.drag_to(container)
 
       subject.find("//*[@class='triggered']").size.should == 1
+    end
+
+    context "raises error when" do
+      it "tries to click an invisible element" do
+        expect {
+          subject.find("//*[@id='hidden']").first.click
+        }.to raise_error(Capybara::Driver::Webkit::Node::ElementNotDisplayedError)
+      end
+
+      it "tries to drag an invisible element to a visible one" do
+        draggable = subject.find("//*[@id='invisible-mousedown']").first
+        container = subject.find("//*[@id='mouseup']").first
+
+        expect {
+          draggable.drag_to(container)
+        }.to raise_error(Capybara::Driver::Webkit::Node::ElementNotDisplayedError)
+      end
+
+      it "tries to drag a visible element to an invisible one" do
+        draggable = subject.find("//*[@id='mousedown']").first
+        container = subject.find("//*[@id='invisible-mouseup']").first
+
+        expect {
+          draggable.drag_to(container)
+        }.to raise_error(Capybara::Driver::Webkit::Node::ElementNotDisplayedError)
+      end
+
+      it "tries to select an invisible option" do
+        option = subject.find("//option[@id='invisible-option']").first
+        expect {
+          option.select_option
+        }.to raise_error(Capybara::Driver::Webkit::Node::ElementNotDisplayedError)
+      end
     end
   end
 


### PR DESCRIPTION
Also, I think its reasonable to add this to #drag_to, and every other mouse interaction to elements (that we might have in the future).
