### PR TITLE
Trigger text input events with HTML5 text-like fields

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -536,9 +536,13 @@ describe Capybara::Driver::Webkit do
         body = <<-HTML
           <html><body>
             <form action="/" method="GET">
-              <input class="watch" type="text"/>
-              <input class="watch" type="password"/>
               <input class="watch" type="email"/>
+              <input class="watch" type="number"/>
+              <input class="watch" type="password"/>
+              <input class="watch" type="search"/>
+              <input class="watch" type="tel"/>
+              <input class="watch" type="text"/>
+              <input class="watch" type="url"/>
               <textarea class="watch"></textarea>
               <input class="watch" type="checkbox"/>
               <input class="watch" type="radio"/>
@@ -580,23 +584,15 @@ describe Capybara::Driver::Webkit do
        %w{change blur}).flatten
     end
 
-    it "triggers text input events" do
-      subject.find("//input[@type='text']").first.set(newtext)
-      subject.find("//li").map(&:text).should == keyevents
+    %w(email number password search tel text url).each do | field_type |
+      it "triggers text input events on inputs of type #{field_type}" do
+        subject.find("//input[@type='#{field_type}']").first.set(newtext)
+        subject.find("//li").map(&:text).should == keyevents
+      end
     end
 
     it "triggers textarea input events" do
       subject.find("//textarea").first.set(newtext)
-      subject.find("//li").map(&:text).should == keyevents
-    end
-
-    it "triggers password input events" do
-      subject.find("//input[@type='password']").first.set(newtext)
-      subject.find("//li").map(&:text).should == keyevents
-    end
-
-    it "triggers email input events" do
-      subject.find("//input[@type='email']").first.set(newtext)
       subject.find("//li").map(&:text).should == keyevents
     end
 

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -139,21 +139,25 @@ Capybara = {
     return this.nodes[index].value;
   },
 
-  set: function(index, value) {
-    var node = this.nodes[index];
-    var type = (node.type || node.tagName).toLowerCase();
-    if (type == "text" || type == "textarea" || type == "password" || type == "email") {
+  set: function (index, value) {
+    var length, maxLength, node, strindex, textTypes, type;
+
+    node = this.nodes[index];
+    type = (node.type || node.tagName).toLowerCase();
+    textTypes = ["email", "number", "password", "search", "tel", "text", "textarea", "url"];
+
+    if (textTypes.indexOf(type) != -1) {
       this.trigger(index, "focus");
-      node.value = "";
-      var maxLength = this.attribute(index, "maxlength"),
-          length;
+
+      maxLength = this.attribute(index, "maxlength");
       if (maxLength && value.length > maxLength) {
         length = maxLength;
       } else {
         length = value.length;
       }
 
-      for(var strindex = 0; strindex < length; strindex++) {
+      node.value = "";
+      for (strindex = 0; strindex < length; strindex++) {
         node.value += value[strindex];
         this.trigger(index, "keydown");
         this.keypress(index, false, false, false, false, 0, value[strindex]);
@@ -161,13 +165,16 @@ Capybara = {
       }
       this.trigger(index, "change");
       this.trigger(index, "blur");
-    } else if(type == "checkbox" || type == "radio") {
-      node.checked = (value == "true");
+
+    } else if (type === "checkbox" || type === "radio") {
+      node.checked = (value === "true");
       this.trigger(index, "click");
       this.trigger(index, "change");
-    } else if(type == "file") {
+
+    } else if (type === "file") {
       this.lastAttachedFile = value;
       this.trigger(index, "click");
+
     } else {
       node.value = value;
     }


### PR DESCRIPTION
In addition to inputs with a type of email (handled already in #106,) HTML5 adds four more types represented as text controls: number, search, tel, and url.

http://www.w3.org/TR/html5/the-input-element.html#attr-input-type

This patch applies the events already setup for email, password, and text to number, search, tel, and url and cleans up those areas I touched. It doesn't apply type specific behaviors, e.g., stripping non-numeric characters from a number input when change is fired, or spinner events.
