### PR TITLE
Note about listening on port 8200 is out of date

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,6 @@ Code for rendering the current webpage to a PNG is borrowed from Phantom.js' imp
 
 The names and logos for thoughtbot are trademarks of thoughtbot, inc.
 
-Notes
------
-
-capybara-webkit will listen on port 8200. This may conflict with other services.
-
 License
 -------
 


### PR DESCRIPTION
Capybara webkit no longer listens on a static port, it takes the first one available.
