### PR TITLE
Make the server bind to localhost. We don't really want to expose it to ...

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -12,7 +12,7 @@ Server::Server(QObject *parent, bool ignoreSslErrors) : QObject(parent) {
 
 bool Server::start() {
   connect(m_tcp_server, SIGNAL(newConnection()), this, SLOT(handleConnection()));
-  return m_tcp_server->listen(QHostAddress::Any, 0);
+  return m_tcp_server->listen(QHostAddress::LocalHost, 0);
 }
 
 quint16 Server::server_port() const {


### PR DESCRIPTION
...the world, and it pops up firewall warnings if you have an app aware firewall enabled (e.g. OSX firewall).
