### PR TITLE
Add support for HTML(5) input event

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -600,6 +600,7 @@ describe Capybara::Driver::Webkit do
                 element.addEventListener("keydown", recordEvent);
                 element.addEventListener("keypress", recordEvent);
                 element.addEventListener("keyup", recordEvent);
+                element.addEventListener("input", recordEvent);
                 element.addEventListener("change", recordEvent);
                 element.addEventListener("blur", recordEvent);
                 element.addEventListener("mousedown", recordEvent);
@@ -619,7 +620,7 @@ describe Capybara::Driver::Webkit do
 
     let(:keyevents) do
       (%w{focus} +
-       newtext.length.times.collect { %w{keydown keypress keyup} } +
+       newtext.length.times.collect { %w{keydown keypress keyup input} } +
        %w{change blur}).flatten
     end
 

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -176,6 +176,7 @@ Capybara = {
         this.trigger(index, "keydown");
         this.keypress(index, false, false, false, false, 0, value[strindex]);
         this.trigger(index, "keyup");
+        this.trigger(index, "input");
       }
       this.trigger(index, "change");
       this.trigger(index, "blur");


### PR DESCRIPTION
The input event is like onchange, but on text fields, it is fired as soon as the value of the field changes, not when the field is blurred. It is a more appropriate event than 'keydown' or 'keyup', which behave unpredictably with paste events, held-down keys, etc.

Support is a little problematic, but it is supported well by Webkit and Firefox, so it seems useful to add here.
# 

I'm using this event in my app, and it works great in Webkit and Firefox, but capybara-webkit doesn't fire it, so tests break.

More details:

See the spec: http://www.whatwg.org/specs/web-apps/current-work/multipage/common-input-element-attributes.html#event-input-input

The best discussion on cross-browser implementation is here: http://bugs.jquery.com/ticket/9121 -- basically, you can detect browsers, and on unsupported browsers (basically IE), use the old keyup/keydown/change events in the old hacky way.
