### PR TITLE
Pass proper keycode to keypress event

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -1408,4 +1408,34 @@ describe Capybara::Driver::Webkit do
       subject.body.should include "Congrats"
     end
   end
+
+  context "keypress app" do
+    before(:all) do
+      @app = lambda do |env|
+        body = <<-HTML
+            <html>
+              <head><title>Form</title></head>
+              <body>
+                <div id="charcode_value"></div>
+                <input type="text" id="charcode" name="charcode" onkeypress="setcharcode" />
+                <script type="text/javascript">
+                  var element = document.getElementById("charcode")
+                  element.addEventListener("keypress", setcharcode);
+                  function setcharcode(event) {
+                    var element = document.getElementById("charcode_value");
+                    element.innerHTML = event.charCode;
+                  }
+                </script>
+              </body>
+            </html>
+        HTML
+        [200, { 'Content-Type' => 'text/html', 'Content-Length' => body.length.to_s }, [body]]
+      end
+    end
+
+    it "returns the charCode for the keypressed" do
+      subject.find("//input")[0].set("a")
+      subject.find("//div")[0].text.should == "97"
+    end
+  end
 end

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -174,7 +174,7 @@ Capybara = {
       for (strindex = 0; strindex < length; strindex++) {
         node.value += value[strindex];
         this.trigger(index, "keydown");
-        this.keypress(index, false, false, false, false, 0, value[strindex]);
+        this.keypress(index, false, false, false, false, 0, value.charCodeAt(strindex));
         this.trigger(index, "keyup");
       }
       this.trigger(index, "change");


### PR DESCRIPTION
Currently keypress would pass in string values instead of keycodes. Now "a" gets changed to 97, etc.
