### PR TITLE
automatic JSON parsing of result from #evaluate_script not always a good thing

### DIFF
--- a/lib/capybara/driver/webkit/browser.rb
+++ b/lib/capybara/driver/webkit/browser.rb
@@ -97,7 +97,7 @@ class Capybara::Driver::Webkit
 
     def evaluate_script(script)
       json = command('Evaluate', script)
-      JSON.parse("[#{json}]").first
+      JSON.parse("[#{json}]").first rescue json
     end
 
     def execute_script(script)

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -96,6 +96,13 @@ describe Capybara::Driver::Webkit do
       end
     end
 
+    it "returns a string if JSON parsing fails" do
+      subject.within_frame("f") do
+        result = subject.evaluate_script(%<document.getElementsByTagName('script')[0].textContent>)
+        result.should == "\"\n                document.write(\\\"<p id='farewell'>goodbye</p>\\\");\n              \""
+      end
+    end
+
     it "executes Javascript" do
       subject.within_frame("f") do
         subject.execute_script(%<document.getElementById('farewell').innerHTML = 'yo'>)


### PR DESCRIPTION
I get that it's generally pretty convenient to have that string be JSON parsed, but once in awhile I just want the raw string back (especially when trying to see that js confirmations have the correct text).

Anyway if that call to JSON.parse fails, then you're out of luck.  This commit simply rescues with the string that was fed to JSON.parse (the raw result of the evaluate_script call).

Just for some context, this is what I wanted to do in my project:

```
match = page.evaluate_script(%Q|$('#offer-#{counter_offer.id} input[value="Accept"]').attr('onclick').toString()")|)
match.should include(expected_message)
```
