### PR TITLE
Added empty invalid_element_errors method.

### DIFF
--- a/lib/capybara/driver/webkit.rb
+++ b/lib/capybara/driver/webkit.rb
@@ -122,6 +122,10 @@ class Capybara::Driver::Webkit
     @cookie_jar ||= CookieJar.new(browser)
   end
 
+  def invalid_element_errors
+    []
+  end
+
   private
 
   def url(path)


### PR DESCRIPTION
Driver does not inherit from Base driver and was intermittently causing the following error:

undefined method `invalid_element_errors' for #<Capybara::Driver::Webkit:0x...> (NoMethodError)
      (eval):2:in`has_content?'
