### PR TITLE
Fixes issue with Umlauts in Makefile

### DIFF
--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -28,11 +28,21 @@ module CapybaraWebkitBuilder
   end
 
   def makefile
-    system("LANG='en_US.UTF-8' #{qmake_bin} -spec #{spec}")
+    system("#{qmake_bin} -spec #{spec}")
+    convert_makefile_from_latin1_to_utf8_if_necessary
   end
 
   def qmake
-    system("LANG='en_US.UTF-8' #{make_bin} qmake")
+    system("#{make_bin} qmake")
+    convert_makefile_from_latin1_to_utf8_if_necessary
+  end
+  
+  def makefile_in_latin1?
+    `file Makefile`.include?("ISO-8859")
+  end
+  
+  def convert_makefile_from_latin1_to_utf8_if_necessary
+    system("iconv -f latin1 -t utf8 Makefile > Makefile.utf8 && mv Makefile.utf8 Makefile") if makefile_in_latin1?
   end
 
   def build


### PR DESCRIPTION
https://github.com/thoughtbot/capybara-webkit/issues/224

Worked when installing as a gem from github.

tobias@mbp-tobias /private/tmp/capybara $ bundle
Updating https://github.com/tobstarr/capybara-webkit.git
Fetching source index for http://rubygems.org/
Using mime-types (1.17.2) 
Installing nokogiri (1.5.2) with native extensions 
Using rack (1.4.1) 
Using rack-test (0.6.1) 
Using ffi (1.0.11) 
Using childprocess (0.3.1) 
Using multi_json (1.1.0) 
Using rubyzip (0.9.6.1) 
Installing selenium-webdriver (2.20.0) 
Using xpath (0.1.4) 
Using capybara (1.1.2) 
Using json (1.6.5) 
Using capybara-webkit (0.10.1) from https://github.com/tobstarr/capybara-webkit.git (at 82ced34) with native extensions 
Using bundler (1.0.21) 
Your bundle is complete! Use `bundle show [gemname]` to see where a bundled gem is installed.
