### PR TITLE
Add inner_html and inner_html= methods

### DIFF
--- a/lib/capybara/driver/webkit/node.rb
+++ b/lib/capybara/driver/webkit/node.rb
@@ -7,6 +7,14 @@ class Capybara::Driver::Webkit
       invoke("text").gsub(NBSP, ' ').gsub(/\s+/u, ' ').strip
     end
 
+		def inner_html
+      invoke("innerHTML")
+    end
+
+		def inner_html=(content)
+      invoke("setInnerHTML", content)
+    end
+
     def [](name)
       value = invoke("attribute", name)
       if name == 'checked' || name == 'disabled'

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -41,6 +41,16 @@ Capybara = {
     }
   },
 
+  innerHTML: function (index) {
+    var node = this.nodes[index];
+    return node.innerHTML;
+  },
+
+  setInnerHTML: function (index, content) {
+    var node = this.nodes[index];
+    return node.innerHTML = content;
+  },
+
   attribute: function (index, name) {
     switch(name) {
     case 'checked':


### PR DESCRIPTION
I just add 2 methods to get the "innerHTML" of a node and to update it:

``` ruby
node.base.inner_html                                    # return the innerHTML of the node
node.base.inner_html = "<b>hello</b> world!" # update the innerHTML
```

Frederic
