### PR TITLE
discover_server_port with timeout

### DIFF
--- a/lib/capybara/driver/webkit/browser.rb
+++ b/lib/capybara/driver/webkit/browser.rb
@@ -5,6 +5,8 @@ require 'json'
 
 class Capybara::Driver::Webkit
   class Browser
+    WEBKIT_SERVER_START_TIMEOUT = 15
+
     attr :server_port
 
     def initialize(options = {})
@@ -172,15 +174,8 @@ class Capybara::Driver::Webkit
     end
 
     def discover_server_port(read_pipe)
-      return unless IO.select([read_pipe], nil, nil, 10)
-      port = nil
-      Timeout.timeout(5) do
-        while !port
-          match = (read_pipe.first || '').match(/listening on port: (\d+)/)
-          port = match[1].to_i if match
-        end
-      end
-      port
+      return unless IO.select([read_pipe], nil, nil, WEBKIT_SERVER_START_TIMEOUT)
+      ((read_pipe.first || '').match(/listening on port: (\d+)/) || [])[1].to_i
     end
 
     def forward_stdout(pipe)


### PR DESCRIPTION
Fallback to multiple tries to discover the server port in case starting of webkit_server takes longer than expected. For me, the pipe got the server output just a second after discover_server_port ran, so that the port could not be looked up.
