### PR TITLE
Read from socket only when there's content

### DIFF
--- a/lib/capybara/driver/webkit/browser.rb
+++ b/lib/capybara/driver/webkit/browser.rb
@@ -220,7 +220,7 @@ class Capybara::Driver::Webkit
 
       if result.nil?
         raise WebkitNoResponseError, "No response received from the server."
-      elsif result != 'ok' 
+      elsif result != 'ok'
         raise WebkitInvalidResponseError, read_response
       end
 
@@ -229,7 +229,7 @@ class Capybara::Driver::Webkit
 
     def read_response
       response_length = @socket.gets.to_i
-      response = @socket.read(response_length)
+      response = response_length > 0 ? @socket.read(response_length) : ''
       response.force_encoding("UTF-8") if response.respond_to?(:force_encoding)
       response
     end

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -181,4 +181,33 @@ describe Capybara::Driver::Webkit::Browser do
       @proxy_requests.size.should == 0
     end
   end
+
+  describe "#read_response" do
+    let(:socket) { double("socket") }
+
+    context "when there's something to read" do
+      it "should read from socket" do
+        socket.stub_chain(:gets, :to_i).and_return 1
+        browser.instance_variable_set(:@socket, socket)
+        socket.should_receive(:read).with(1).and_return "A"
+        browser.send(:read_response)
+      end
+    end
+
+    context "when there nothing to read" do
+      before do
+        socket.stub_chain(:gets, :to_i).and_return 0
+        browser.instance_variable_set(:@socket, socket)
+      end
+
+      it "should not read from socket" do
+        socket.should_not_receive(:read)
+        browser.send(:read_response)
+      end
+
+      it "should return an empty string" do
+        browser.send(:read_response).should eq ''
+      end
+    end
+  end
 end


### PR DESCRIPTION
This works around an issue with the TCPSocket class in jruby that causes
it to block indefinitely while trying to read a non-existent response.
MRI will immediately return an empty string.

The fix was to a private method and required stubbing an instance
variable not publically accessible so the specs have to get kind of cute
to work around this.

This pull request closes issue #197 and supersedes pull request #220
(which had broken specs). Credit @duelinmarkers.
