### PR TITLE
Fix for windows compilation issue

### DIFF
--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -63,8 +63,8 @@ module CapybaraWebkitBuilder
   end
 
   def build_all
-    makefile &&
-    qmake &&
+    makefile
+    qmake
     build
   end
 end


### PR DESCRIPTION
On windows, 

```
gem install capybara-webkit
```

 fails with the following message:

```
ERROR: Failed to build gem native extension
C:/Ruby192/bin/ruby.exe extconf.rb
```

Removing the "&&"s from "build_all" resolves the issue and binaries build correctly.
