### PR TITLE
Note render command's dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ capybara-webkit supports a few methods that are not part of the standard capybar
     page.driver.evaluate_script("window.innerWidth")
     => 500
 
-**render**: render a screenshot of the current view
+**render**: render a screenshot of the current view (requires [mini_magick](https://github.com/probablycorey/mini_magick) and [ImageMagick](http://www.imagemagick.org))
 
     page.driver.render "tmp/screenshot.png"
 


### PR DESCRIPTION
If `page.driver.render` needs mini_magick and ImageMagick installed, it'd be friendly to suggest it.
