### PR TITLE
Add empty invalid_element_errors method to the driver interface

### DIFF
--- a/lib/capybara/driver/webkit.rb
+++ b/lib/capybara/driver/webkit.rb
@@ -122,6 +122,10 @@ class Capybara::Driver::Webkit
     @rack_server.port
   end
 
+  def invalid_element_errors
+    []
+  end
+
   def cookies
     @cookie_jar ||= CookieJar.new(browser)
   end

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -349,6 +349,10 @@ describe Capybara::Driver::Webkit do
       subject.find("//p").first.should be_visible
       subject.find("//*[@id='invisible']").first.should_not be_visible
     end
+
+    it "has no known invalid element errors for capybara" do
+      subject.invalid_element_errors.should be_empty
+    end
   end
 
   context "console messages app" do


### PR DESCRIPTION
Newer versions of capybara require an invalid_element_errors method on the driver object. The base capybara driver returns an empty array; the selenium driver returns a couple of exception classes. I looked through the capybara-webkit source and didn't see any appropriate exceptions, so I have it returning an empty array.

This change was already done by josephbridgwaterrowe, but he didn't include a spec, so his pull request was closed. https://github.com/thoughtbot/capybara-webkit/pull/288

I did include a spec - a pretty simple spec, at that. :) I wasn't sure where to add it, so I put it in the 'hello app' context. I don't mind moving it if there is a better place.

Thanks guy. This is a super helpful project!
