### PR TITLE
explicitly requiring 'capybara/webkit' since it is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Add the capybara-webkit gem to your Gemfile:
 
 Set your Capybara Javascript driver to webkit:
 
+    require 'capybara/webkit'
     Capybara.javascript_driver = :webkit
 
 In cucumber, tag scenarios with @javascript to run them using a headless WebKit browser.


### PR DESCRIPTION
adding 'capybara-webkit' to my gemfile and running bundle exec cucumber did not automatically require 'capybara/webkit' for me so I added it to the readme
