### PR TITLE
#362: Capybara-webkit fails installation on Ubuntu server 12.04

### DIFF
--- a/src/TimeoutCommand.cpp
+++ b/src/TimeoutCommand.cpp
@@ -2,7 +2,7 @@
 #include "Command.h"
 #include "WebPageManager.h"
 #include "WebPage.h"
-#include <QTimer.h>
+#include <QTimer>
 
 TimeoutCommand::TimeoutCommand(Command *command, WebPageManager *manager, QObject *parent) : Command(parent) {
   m_command = command;


### PR DESCRIPTION
issue: https://github.com/thoughtbot/capybara-webkit/issues/362
Include QTimer library has been updated.
