### PR TITLE
Allow rbx to fail in 1.9 mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
 rvm:
   - 1.9.3
+  - rbx-19mode
+matrix:
+  allow_failures:
+    - rvm: rbx-19mode
 notifications:
   email: false
 script: xvfb-run rake


### PR DESCRIPTION
In support of rubinius/rubinius#2006 please consider testing Rubinius in 1.9 mode on Travis.

I didn't add `rbx-18mode` because you aren't testing against `MRI 1.8` but if you would like to test against `rbx` in `1.8` mode please do!
