### PR TITLE
Use MatchArray to compare event arrays.

### DIFF
--- a/spec/selenium_compatibility_spec.rb
+++ b/spec/selenium_compatibility_spec.rb
@@ -38,7 +38,7 @@ describe Capybara::Webkit, 'compatibility with selenium' do
   end
 
   def compare_events_for_drivers(first, second, &block)
-    events_for_driver(first, &block).should == events_for_driver(second, &block)
+    events_for_driver(first, &block).should =~ events_for_driver(second, &block)
   end
 
   def events_for_driver(name, &block)


### PR DESCRIPTION
The events_for_driver method in the selenium_compatibility_spec was returning
differently ordered arrays. Switch to MatchArray to compare array contents
without requiring them to be ordered the same.

This change fixes a failing spec on rubinius and is in support of https://github.com/rubinius/rubinius/issues/2006
