### PR TITLE
Support console messages from unknown sources

### DIFF
--- a/lib/capybara/webkit/browser.rb
+++ b/lib/capybara/webkit/browser.rb
@@ -45,7 +45,10 @@ module Capybara::Webkit
     def console_messages
       command("ConsoleMessages").split("\n").map do |messages|
         parts = messages.split("|", 3)
-        { :source => parts.first, :line_number => Integer(parts[1]), :message => parts.last.gsub("\\n", "\n") }
+        message = parts.pop.gsub("\\n", "\n")
+        { :source => parts.first, :message => message }.tap do |message|
+          message[:line_number] = Integer(parts[1]) if parts[1]
+        end
       end
     end
 

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -457,6 +457,13 @@ describe Capybara::Webkit::Driver do
       driver.reset!
       driver.console_messages.should be_empty
     end
+
+    it "supports console messages from an unknown source" do
+      driver.execute_script("console.log('hello')")
+      driver.console_messages.last[:message].should == 'hello'
+      driver.console_messages.last[:source].should be_nil
+      driver.console_messages.last[:line_number].should be_nil
+    end
   end
 
   context "javascript dialog interaction" do

--- a/src/WebPage.cpp
+++ b/src/WebPage.cpp
@@ -134,10 +134,10 @@ QVariant WebPage::invokeCapybaraFunction(QString &name, const QStringList &argum
 }
 
 void WebPage::javaScriptConsoleMessage(const QString &message, int lineNumber, const QString &sourceID) {
-  QString fullMessage = QString::number(lineNumber) + "|" + QString(message).replace("\n", "\\n");;
+  QString fullMessage = QString(message);
   if (!sourceID.isEmpty())
-    fullMessage = sourceID + "|" + fullMessage;
-  m_consoleMessages.append(fullMessage);
+    fullMessage = sourceID + "|" + QString::number(lineNumber) + "|" + fullMessage;
+  m_consoleMessages.append(fullMessage.replace("\n", "\\n"));
   std::cout << qPrintable(fullMessage) << std::endl;
 }
 


### PR DESCRIPTION
There's no use in recording the line number if we don't know the source.

Fixes #416.
