### PR TITLE
Rescue from Errno::ESRCH in the exit hook in case webkit_server has alre...

### DIFF
--- a/lib/capybara/webkit/connection.rb
+++ b/lib/capybara/webkit/connection.rb
@@ -62,6 +62,8 @@ module Capybara::Webkit
       else
         Process.kill("INT", @pid)
       end
+    rescue Errno::ESRCH
+      # This just means that the webkit_server process has already ended
     end
 
     def discover_port


### PR DESCRIPTION
This just prevents exceptions from being raised on the exit hook if the webkit server process has already ended, e.g. crashed or killed externally.
