### PR TITLE
Fix authentication time outs.

### DIFF
--- a/src/NetworkAccessManager.cpp
+++ b/src/NetworkAccessManager.cpp
@@ -62,8 +62,10 @@ void NetworkAccessManager::setPassword(const QString &password) {
 
 void NetworkAccessManager::provideAuthentication(QNetworkReply *reply, QAuthenticator *authenticator) {
   Q_UNUSED(reply);
-  authenticator->setUser(m_userName);
-  authenticator->setPassword(m_password);
+  if (m_userName != authenticator->user()) 
+    authenticator->setUser(m_userName);
+  if (m_password != authenticator->password())
+    authenticator->setPassword(m_password);
 }
 
 int NetworkAccessManager::statusFor(QUrl url) {


### PR DESCRIPTION
If the incorrect credentials are provided QNetworkAccessManager just keeps
firing the same signal and it gets stuck in a infinite loop. This change only
sets the user name and password if they are different to the current user
name and password, causing the event to not be continuously triggered after
failed authentications.
