### PR TITLE
Make Node#text work for svg elements

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -472,6 +472,26 @@ describe Capybara::Webkit::Driver do
     end
   end
 
+  context "svg app" do
+    let(:driver) do
+      driver_for_html(<<-HTML)
+        <html>
+          <body>
+            <svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="100">
+              <text x="10" y="25" fill="navy" font-size="15" id="navy_text">In the navy!</text>
+            </svg>
+          </body>
+        </html>
+      HTML
+    end
+
+    before { visit("/") }
+
+    it "should handle text for svg elements" do
+      driver.find("//*[@id='navy_text']").first.text.should == "In the navy!"
+    end
+  end
+
   context "console messages app" do
     let(:driver) do
       driver_for_html(<<-HTML)

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -38,7 +38,10 @@ Capybara = {
   text: function (index) {
     var node = this.nodes[index];
     var type = (node.type || node.tagName).toLowerCase();
-    if (type == "textarea") {
+    // SVG elements do not have the non standardized innerText attribute
+    if (node.namespaceURI == 'http://www.w3.org/2000/svg') {
+      return node.textContent;
+    } else if (type == "textarea") {
       return node.innerHTML;
     } else {
       return node.innerText;


### PR DESCRIPTION
svg elements don't return to the non standard innerText attribute so
fall back on the standard textContent when innerText is null.

Fixes #437.
