### PR TITLE
Ignore custom fonts applied to pseudo elements

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -1308,10 +1308,16 @@ describe Capybara::Webkit::Driver do
           <head>
             <style type="text/css">
               p { font-family: "Verdana"; }
+              p:before { font-family: "Verdana"; }
+              p:after { font-family: "Verdana"; }
+              #first-line-div:first-line { font-family: "Verdana"; }
+              #first-letter-div:first-letter { font-family: "Verdana"; }
             </style>
           </head>
           <body>
             <p id="text">Hello</p>
+            <p id="first-line-div">Hello first line.</p>
+            <p id="first-letter-div">Hello first letter.</p>
           </body>
         </html>
       HTML
@@ -1323,6 +1329,38 @@ describe Capybara::Webkit::Driver do
       font_family = driver.evaluate_script(<<-SCRIPT)
         var element = document.getElementById("text");
         element.ownerDocument.defaultView.getComputedStyle(element, null).getPropertyValue("font-family");
+      SCRIPT
+      font_family.should == "Arial"
+    end
+
+    it "ignores custom fonts before an element" do
+      font_family = driver.evaluate_script(<<-SCRIPT)
+        var element = document.getElementById("text");
+        element.ownerDocument.defaultView.getComputedStyle(element, 'before').getPropertyValue("font-family");
+      SCRIPT
+      font_family.should == "Arial"
+    end
+
+    it "ignores custom fonts after an element" do
+      font_family = driver.evaluate_script(<<-SCRIPT)
+        var element = document.getElementById("text");
+        element.ownerDocument.defaultView.getComputedStyle(element, 'after').getPropertyValue("font-family");
+      SCRIPT
+      font_family.should == "Arial"
+    end
+
+    it "ignores custom fonts applied to the first-line pseudo element" do
+      font_family = driver.evaluate_script(<<-SCRIPT)
+        var element = document.getElementById("first-line-div");
+        element.ownerDocument.defaultView.getComputedStyle(element, 'first-line').getPropertyValue("font-family");
+      SCRIPT
+      font_family.should == "Arial"
+    end
+
+    it "ignores custom fonts applied to the first-letter pseudo element" do
+      font_family = driver.evaluate_script(<<-SCRIPT)
+        var element = document.getElementById("first-letter-div");
+        element.ownerDocument.defaultView.getComputedStyle(element, 'first-letter').getPropertyValue("font-family");
       SCRIPT
       font_family.should == "Arial"
     end

--- a/src/WebPage.cpp
+++ b/src/WebPage.cpp
@@ -70,7 +70,7 @@ void WebPage::loadJavascript() {
 }
 
 void WebPage::setUserStylesheet() {
-  QString data = QString("* { font-family: 'Arial' ! important; }").toUtf8().toBase64();
+  QString data = QString("*, :first-line, :first-letter, :before, :after { font-family: 'Arial' ! important; }").toUtf8().toBase64();
   QUrl url = QUrl(QString("data:text/css;charset=utf-8;base64,") + data);
   settings()->setUserStyleSheetUrl(url);
 }


### PR DESCRIPTION
WebPage::setUserStylesheet prevents Web Fonts from loading when styles
are applied directly to elements, however if the styles are applied to
pseudo elements, the override does not apply. This leads to crashes on
Mac OS X, likely due to https://bugs.webkit.org/show_bug.cgi?id=61031.

Fixes #181.
