### PR TITLE
Add Vagrant configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp
 .rvmrc
 src/debug
 webkit_server.pro.user
+.vagrant

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,24 @@
 We love pull requests. Here's a quick guide:
 
-Dependencies
+## Dependencies
 
 Some of the tests depend on the `identify` command that comes with Imagemagick.
-Imagemagick can be installed via [homebrew](http://mxcl.github.com/homebrew/).
+Imagemagick can be installed via [homebrew](http://mxcl.github.com/homebrew/) on
+Mac OS X:
 
     brew install imagemagick
 
-Contributing
+If you prefer, you can use a [Vagrant](http://www.vagrantup.com/) virtual
+machine. The Vagrantfile in the capybara-webkit repository will get you up and
+running with all the development dependencies:
+
+    gem install vagrant
+    vagrant up
+    vagrant ssh
+    cd /vagrant
+    rake
+
+## Contributing
 
 1. Fork the repo.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,7 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant::Config.run do |config|
+  config.vm.box = "precise32"
+  config.vm.provision :shell, :path => 'vagrant_setup.sh'
+end

--- a/vagrant_setup.sh
+++ b/vagrant_setup.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+export DISPLAY=:99
+
+apt-get -y update
+apt-get -y install ruby1.9.1-dev
+
+if [ -z `which make` ]; then apt-get -y install build-essential; fi
+if [ -z `which qmake` ]; then apt-get -y install libqt4-dev libicu48; fi
+if [ -z `which git` ]; then apt-get -y install git-core; fi
+if [ -z `which xml2-config` ]; then apt-get -y install libxml2-dev; fi
+if [ -z `which xslt-config` ]; then apt-get -y install libxslt-dev; fi
+if [ -z `which convert` ]; then apt-get -y install imagemagick; fi
+if [ -z `which firefox` ]; then apt-get -y install firefox; fi
+
+if [ -z `which bundle` ];
+then
+  gem install bundler
+  cd /vagrant
+  bundle
+fi
+
+if [ ! -f /etc/init.d/xvfb ];
+then
+  apt-get -y install xvfb
+  echo "export DISPLAY=${DISPLAY}" >> /home/vagrant/.bashrc
+  tee /etc/init.d/xvfb <<-EOF
+    #!/bin/bash
+
+    XVFB=/usr/bin/Xvfb
+    XVFBARGS="\$DISPLAY -ac -screen 0 1024x768x16"
+    PIDFILE=\${HOME}/xvfb_\${DISPLAY:1}.pid
+    case "\$1" in
+      start)
+        echo -n "Starting virtual X frame buffer: Xvfb"
+        /sbin/start-stop-daemon --start --quiet --pidfile \$PIDFILE --make-pidfile --background --exec \$XVFB -- \$XVFBARGS
+        echo "."
+        ;;
+      stop)
+        echo -n "Stopping virtual X frame buffer: Xvfb"
+        /sbin/start-stop-daemon --stop --quiet --pidfile \$PIDFILE
+        echo "."
+        ;;
+      restart)
+        \$0 stop
+        \$0 start
+        ;;
+      *)
+        echo "Usage: /etc/init.d/xvfb {start|stop|restart}"
+        exit 1
+    esac
+    exit 0
+EOF
+
+  chmod +x /etc/init.d/xvfb
+fi
+
+/etc/init.d/xvfb start


### PR DESCRIPTION
capybara-webkit has various development dependencies which can be a little
cumbersome to manage. With [Vagrant](http://www.vagrantup.com) they can all be nicely bundled up in a VM and
installed automatically. My personal preference is to use Vagrant for anything that depends on anything outside of its Gemfile (in this case Qt and ImageMagick).

It's hard to test this automatically, but it can be manually tested using something along these lines:

```
gem install vagrant
cd capybara-webkit

# First run will set up the VM and run vagrant_setup.sh
vagrant up

# Run the capybara-webkit tests on the VM
vagrant ssh
cd /vagrant
rake
exit

# Restart the VM, second run of vagrant_setup.sh will be much quicker
vagrant halt
vagrant up

# Run the capybara-webkit tests on the VM
vagrant ssh
cd /vagrant
rake
exit
```
