### PR TITLE
Add Driver#version to print version info

### DIFF
--- a/lib/capybara/webkit/browser.rb
+++ b/lib/capybara/webkit/browser.rb
@@ -189,6 +189,10 @@ module Capybara::Webkit
       command("ResizeWindow", width.to_i, height.to_i)
     end
 
+    def version
+      command("Version")
+    end
+
     private
 
     def check

--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -164,6 +164,12 @@ module Capybara::Webkit
       []
     end
 
-    private
+    def version
+      [
+        "Capybara: #{Capybara::VERSION}",
+        "capybara-webkit: #{Capybara::Driver::Webkit::VERSION}",
+        browser.version
+      ].join("\n")
+    end
   end
 end

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -2142,6 +2142,25 @@ describe Capybara::Webkit::Driver do
     end
   end
 
+  context "version" do
+    let(:driver) do
+      driver_for_html(<<-HTML)
+        <html><body></body></html>
+      HTML
+    end
+
+    before { visit("/") }
+
+    it "includes Capybara, capybara-webkit, Qt, and WebKit versions" do
+      result = driver.version
+      result.should include("Capybara: #{Capybara::VERSION}")
+      result.should include("capybara-webkit: #{Capybara::Driver::Webkit::VERSION}")
+      result.should =~ /Qt: \d+\.\d+\.\d+/
+      result.should =~ /WebKit: \d+\.\d+/
+      result.should =~ /QtWebKit: \d+\.\d+/
+    end
+  end
+
   def driver_url(driver, path)
     URI.parse(driver.current_url).merge(path).to_s
   end

--- a/src/CommandFactory.cpp
+++ b/src/CommandFactory.cpp
@@ -38,6 +38,7 @@
 #include "JavascriptConfirmMessages.h"
 #include "JavascriptPromptMessages.h"
 #include "SetUrlBlacklist.h"
+#include "Version.h"
 
 CommandFactory::CommandFactory(WebPageManager *manager, QObject *parent) : QObject(parent) {
   m_manager = manager;

--- a/src/Version.cpp
+++ b/src/Version.cpp
@@ -1,0 +1,13 @@
+#include "Version.h"
+#include "WebPage.h"
+
+Version::Version(WebPageManager *manager, QStringList &arguments, QObject *parent) : SocketCommand(manager, arguments, parent) {
+}
+
+void Version::start() {
+  QString result =
+    QString("Qt: ") + QT_VERSION_STR +
+    QString("\nWebKit: ") + qWebKitVersion() +
+    QString("\nQtWebKit: ") + QTWEBKIT_VERSION_STR;
+  emitFinished(true, result);
+}

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,0 +1,10 @@
+#include "SocketCommand.h"
+
+class Version : public SocketCommand {
+  Q_OBJECT
+
+  public:
+    Version(WebPageManager *, QStringList &arguments, QObject *parent = 0);
+    virtual void start();
+};
+

--- a/src/find_command.h
+++ b/src/find_command.h
@@ -40,3 +40,4 @@ CHECK_COMMAND(GetTimeout)
 CHECK_COMMAND(SetTimeout)
 CHECK_COMMAND(SetUrlBlacklist)
 
+CHECK_COMMAND(Version)

--- a/src/webkit_server.pro
+++ b/src/webkit_server.pro
@@ -2,6 +2,7 @@ TEMPLATE = app
 TARGET = webkit_server
 DESTDIR = .
 HEADERS = \
+  Version.h \
   EnableLogging.h \
   Authenticate.h \
   SetConfirmAction.h \
@@ -58,6 +59,7 @@ HEADERS = \
   JsonSerializer.h
 
 SOURCES = \
+  Version.cpp \
   EnableLogging.cpp \
   Authenticate.cpp \
   SetConfirmAction.cpp \


### PR DESCRIPTION
- Prints version of major components
- Includes capybara, capybara-webkit, Qt, WebKit, QtWebKit
- Useful for debugging available features
