### PR TITLE
Allowing nil content-type with UnsupportedContentHandler

### DIFF
--- a/src/WebPage.cpp
+++ b/src/WebPage.cpp
@@ -269,14 +269,15 @@ NetworkAccessManager *WebPage::networkAccessManager() {
 
 void WebPage::handleUnsupportedContent(QNetworkReply *reply) {
   QVariant contentMimeType = reply->header(QNetworkRequest::ContentTypeHeader);
-  if(!contentMimeType.isNull()) {
-    triggerAction(QWebPage::Stop);
-    UnsupportedContentHandler *handler = new UnsupportedContentHandler(this, reply);
-    if (reply->isFinished())
-      handler->renderNonHtmlContent();
-    else
-      handler->waitForReplyToFinish();
-  }
+  if(contentMimeType.isNull())
+    m_manager->logger() << "Warning: no content type from " << reply->url().toString() << "Forcing content type to text/plain.";
+
+  triggerAction(QWebPage::Stop);
+  UnsupportedContentHandler *handler = new UnsupportedContentHandler(this, reply);
+  if (reply->isFinished())
+    handler->renderNonHtmlContent();
+  else
+    handler->waitForReplyToFinish();
 }
 
 bool WebPage::unsupportedContentLoaded() {


### PR DESCRIPTION
- Some websites will not send a Content-Type header when the content  is sent using 'Content-Disposition: "attachment"; filename="<some_file.ext>"'.  Mint.com is one example of this, when downloading transactions to a .csv file.  This patch fixes this problem, and logs a warning if this ever occurs.
