### PR TITLE
Fix test failures from warnings

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -2107,14 +2107,16 @@ describe Capybara::Webkit::Driver do
   describe "logger app" do
     it "logs nothing before turning on the logger" do
       visit("/")
-      log.should == ""
+      log.should_not include logging_message
     end
 
     it "logs its commands after turning on the logger" do
       driver.enable_logging
       visit("/")
-      log.should_not == ""
+      log.should include logging_message
     end
+
+    let(:logging_message) { 'Wrote response true' }
 
     let(:driver) do
       connection = Capybara::Webkit::Connection.new(:stderr => output)


### PR DESCRIPTION
- Some machines print warnings to stderr from plugins
- We can't silence these warnings and the tests fail
- Tests now look for a specific string instead of any output
