### PR TITLE
Implement Node#hover

### DIFF
--- a/gemfiles/2.0.gemfile.lock
+++ b/gemfiles/2.0.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /Users/pivotal/workspace/capybara-webkit
+  remote: /home/mhoran/capybara-webkit
   specs:
     capybara-webkit (0.14.1)
       capybara (~> 2.0, >= 2.0.2)

--- a/gemfiles/2.1.gemfile.lock
+++ b/gemfiles/2.1.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/jnicklas/capybara.git
-  revision: 0c53168899fadee52caced605dd2d6f3e48e6ec4
+  revision: 458bb23a5cc17199aa0989fb0a0b6fb2617be74e
   submodules: true
   specs:
     capybara (2.0.2)
@@ -13,7 +13,7 @@ GIT
       nokogiri (~> 1.3)
 
 PATH
-  remote: /Users/pivotal/workspace/capybara-webkit
+  remote: /home/mhoran/capybara-webkit
   specs:
     capybara-webkit (0.14.1)
       capybara (~> 2.0, >= 2.0.2)

--- a/lib/capybara/webkit/node.rb
+++ b/lib/capybara/webkit/node.rb
@@ -67,6 +67,10 @@ module Capybara::Webkit
       invoke("rightClick")
     end
 
+    def hover
+      invoke("hover")
+    end
+
     def drag_to(element)
       invoke 'dragTo', element.native
     end

--- a/src/JavascriptInvocation.cpp
+++ b/src/JavascriptInvocation.cpp
@@ -38,7 +38,7 @@ InvocationResult JavascriptInvocation::invoke(QWebFrame *frame) {
 void JavascriptInvocation::leftClick(int x, int y) {
   QPoint mousePos(x, y);
 
-  JavascriptInvocation::mouseEvent(QEvent::MouseMove, mousePos, Qt::NoButton);
+  hover(mousePos);
   JavascriptInvocation::mouseEvent(QEvent::MouseButtonPress, mousePos, Qt::LeftButton);
   JavascriptInvocation::mouseEvent(QEvent::MouseButtonRelease, mousePos, Qt::LeftButton);
 }
@@ -46,7 +46,7 @@ void JavascriptInvocation::leftClick(int x, int y) {
 void JavascriptInvocation::rightClick(int x, int y) {
   QPoint mousePos(x, y);
 
-  JavascriptInvocation::mouseEvent(QEvent::MouseMove, mousePos, Qt::NoButton);
+  hover(mousePos);
   JavascriptInvocation::mouseEvent(QEvent::MouseButtonPress, mousePos, Qt::RightButton);
 }
 
@@ -91,4 +91,13 @@ QVariantMap JavascriptInvocation::clickPosition(QWebElement element, int left, i
   m["absoluteY"] = mousePos.y();
 
   return m;
+}
+
+void JavascriptInvocation::hover(int absoluteX, int absoluteY) {
+  QPoint mousePos(absoluteX, absoluteY);
+  hover(mousePos);
+}
+
+void JavascriptInvocation::hover(const QPoint &mousePos) {
+  mouseEvent(QEvent::MouseMove, mousePos, Qt::NoButton);
 }

--- a/src/JavascriptInvocation.h
+++ b/src/JavascriptInvocation.h
@@ -22,6 +22,7 @@ class JavascriptInvocation : public QObject {
     Q_INVOKABLE void doubleClick(int x, int y);
     Q_INVOKABLE bool clickTest(QWebElement element, int absoluteX, int absoluteY);
     Q_INVOKABLE QVariantMap clickPosition(QWebElement element, int left, int top, int width, int height);
+    Q_INVOKABLE void hover(int absoluteX, int absoluteY);
     QVariant getError();
     void setError(QVariant error);
     InvocationResult invoke(QWebFrame *);
@@ -32,5 +33,6 @@ class JavascriptInvocation : public QObject {
     WebPage *m_page;
     QVariant m_error;
     void mouseEvent(QEvent::Type type, const QPoint & position, Qt::MouseButton button);
+    void hover(const QPoint &);
 };
 

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -176,6 +176,15 @@ Capybara = {
     this.click(index, CapybaraInvocation.rightClick);
   },
 
+  hover: function (index) {
+    var node = this.nodes[index];
+    node.scrollIntoViewIfNeeded();
+
+    var pos = this.clickPosition(node);
+    if (pos)
+      CapybaraInvocation.hover(pos.absoluteX, pos.absoluteY);
+  },
+
   trigger: function (index, eventName) {
     var eventObject = document.createEvent("HTMLEvents");
     eventObject.initEvent(eventName, true, true);


### PR DESCRIPTION
Capybara 2.1 introduces Node#hover, which allows testing hover-dependent features.

Note: Our behavior differs from selenium webdriver in that we click in the middle of the first client rectangle instead of the center of the bounding client rectangle. Tests included in the driver spec demonstrate why this is needed.
