### PR TITLE
fix right click spec and implementation

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -991,12 +991,9 @@ describe Capybara::Webkit::Driver do
           <ul id="events"></ul>
           <script type="text/javascript">
             var events = document.getElementById("events");
-            // https://developer.mozilla.org/en-US/docs/DOM/MouseEvent
-            var RIGHT_BUTTON = 2;
             var recordEvent = function (event) {
               var element = document.createElement("li");
-              var type = event.button == RIGHT_BUTTON ? 'contextmenu' : event.type;
-              element.innerHTML = type;
+              element.innerHTML = event.type;
               events.appendChild(element);
             };
 
@@ -1032,7 +1029,7 @@ describe Capybara::Webkit::Driver do
 
     it "triggers right click" do
       watch.right_click
-      fired_events.should == %w(contextmenu)
+      fired_events.should == %w(mousedown contextmenu mouseup)
     end
   end
 

--- a/src/JavascriptInvocation.cpp
+++ b/src/JavascriptInvocation.cpp
@@ -3,6 +3,7 @@
 #include "InvocationResult.h"
 #include <QApplication>
 #include <QEvent>
+#include <QContextMenuEvent>
 
 JavascriptInvocation::JavascriptInvocation(const QString &functionName, const QStringList &arguments, WebPage *page, QObject *parent) : QObject(parent) {
   m_functionName = functionName;
@@ -48,6 +49,12 @@ void JavascriptInvocation::rightClick(int x, int y) {
 
   hover(mousePos);
   JavascriptInvocation::mouseEvent(QEvent::MouseButtonPress, mousePos, Qt::RightButton);
+
+  // swallowContextMenuEvent tries to fire contextmenu event in html page
+  QContextMenuEvent *event = new QContextMenuEvent(QContextMenuEvent::Mouse, mousePos);
+  m_page->swallowContextMenuEvent(event);
+
+  JavascriptInvocation::mouseEvent(QEvent::MouseButtonRelease, mousePos, Qt::RightButton);
 }
 
 void JavascriptInvocation::doubleClick(int x, int y) {


### PR DESCRIPTION
There is a bug in #462.

The bug was that it actually sen't just 'mousedown' event instead of 'contextmenu' one.
Not it fires events like it does in Chrome.
