### PR TITLE
Share the NetworkAccessManager across WebPages

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -2018,7 +2018,17 @@ describe Capybara::Webkit::Driver do
             "401 Unauthorized."
           end
         end
+
+        get "/reset" do
+          headers "WWW-Authenticate" => 'Basic realm="Secure Area"'
+          status 401
+          "401 Unauthorized."
+        end
       end
+    end
+
+    before do
+      visit('/reset')
     end
 
     it "can authenticate a request" do

--- a/src/Authenticate.cpp
+++ b/src/Authenticate.cpp
@@ -1,6 +1,7 @@
 #include "Authenticate.h"
 #include "WebPage.h"
 #include "NetworkAccessManager.h"
+#include "WebPageManager.h"
 
 Authenticate::Authenticate(WebPageManager *manager, QStringList &arguments, QObject *parent) : SocketCommand(manager, arguments, parent) {
 }
@@ -9,7 +10,7 @@ void Authenticate::start() {
   QString username = arguments()[0];
   QString password = arguments()[1];
 
-  NetworkAccessManager* networkAccessManager = page()->networkAccessManager();
+  NetworkAccessManager* networkAccessManager = manager()->networkAccessManager();
   networkAccessManager->setUserName(username);
   networkAccessManager->setPassword(password);
 

--- a/src/Header.cpp
+++ b/src/Header.cpp
@@ -9,7 +9,7 @@ Header::Header(WebPageManager *manager, QStringList &arguments, QObject *parent)
 void Header::start() {
   QString key = arguments()[0];
   QString value = arguments()[1];
-  NetworkAccessManager* networkAccessManager = page()->networkAccessManager();
+  NetworkAccessManager* networkAccessManager = manager()->networkAccessManager();
   if (key.toLower().replace("-", "_") == "user_agent") {
     page()->setUserAgent(value);
   } else {

--- a/src/NetworkAccessManager.cpp
+++ b/src/NetworkAccessManager.cpp
@@ -46,8 +46,10 @@ void NetworkAccessManager::addHeader(QString key, QString value) {
   m_headers.insert(key, value);
 }
 
-void NetworkAccessManager::resetHeaders() {
+void NetworkAccessManager::reset() {
   m_headers.clear();
+  m_userName = QString();
+  m_password = QString();
 }
 
 void NetworkAccessManager::setUserName(const QString &userName) {

--- a/src/NetworkAccessManager.h
+++ b/src/NetworkAccessManager.h
@@ -1,3 +1,5 @@
+#ifndef __NETWORKACCESSMANAGER_H
+#define __NETWORKACCESSMANAGER_H
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkRequest>
 #include <QtNetwork/QNetworkReply>
@@ -10,7 +12,7 @@ class NetworkAccessManager : public QNetworkAccessManager {
   public:
     NetworkAccessManager(QObject *parent = 0);
     void addHeader(QString key, QString value);
-    void resetHeaders();
+    void reset();
     void setUserName(const QString &userName);
     void setPassword(const QString &password);
     void setUrlBlacklist(QStringList urlBlacklist);
@@ -34,3 +36,4 @@ class NetworkAccessManager : public QNetworkAccessManager {
     void requestCreated(QByteArray &url, QNetworkReply *reply);
     void finished(QUrl &, QNetworkReply *);
 };
+#endif

--- a/src/SetProxy.cpp
+++ b/src/SetProxy.cpp
@@ -18,6 +18,6 @@ void SetProxy::start()
                           arguments()[2],
                           arguments()[3]);
 
-  page()->networkAccessManager()->setProxy(proxy);
+  manager()->networkAccessManager()->setProxy(proxy);
   finish(true);
 }

--- a/src/SetUrlBlacklist.cpp
+++ b/src/SetUrlBlacklist.cpp
@@ -8,7 +8,7 @@ SetUrlBlacklist::SetUrlBlacklist(WebPageManager *manager, QStringList &arguments
 }
 
 void SetUrlBlacklist::start() {
-  NetworkAccessManager* networkAccessManager = page()->networkAccessManager();
+  NetworkAccessManager* networkAccessManager = manager()->networkAccessManager();
   networkAccessManager->setUrlBlacklist(arguments());
   finish(true);
 }

--- a/src/WebPage.cpp
+++ b/src/WebPage.cpp
@@ -43,15 +43,13 @@ void WebPage::resetWindowSize() {
 }
 
 void WebPage::setCustomNetworkAccessManager() {
-  NetworkAccessManager *manager = new NetworkAccessManager(this);
-  manager->setCookieJar(m_manager->cookieJar());
-  this->setNetworkAccessManager(manager);
-  connect(manager, SIGNAL(sslErrors(QNetworkReply *, QList<QSslError>)),
-          this, SLOT(handleSslErrorsForReply(QNetworkReply *, QList<QSslError>)));
-  connect(manager, SIGNAL(requestCreated(QByteArray &, QNetworkReply *)),
+  setNetworkAccessManager(m_manager->networkAccessManager());
+  connect(networkAccessManager(), SIGNAL(sslErrors(QNetworkReply *, QList<QSslError>)),
+          SLOT(handleSslErrorsForReply(QNetworkReply *, QList<QSslError>)));
+  connect(networkAccessManager(), SIGNAL(requestCreated(QByteArray &, QNetworkReply *)),
           SIGNAL(requestCreated(QByteArray &, QNetworkReply *)));
-  connect(manager, SIGNAL(finished(QUrl &, QNetworkReply *)),
-      SLOT(replyFinished(QUrl &, QNetworkReply *)));
+  connect(networkAccessManager(), SIGNAL(finished(QUrl &, QNetworkReply *)),
+          SLOT(replyFinished(QUrl &, QNetworkReply *)));
 }
 
 void WebPage::replyFinished(QUrl &requestedUrl, QNetworkReply *reply) {
@@ -289,10 +287,6 @@ QByteArray WebPage::body() {
 
 QString WebPage::contentType() {
   return currentFrame()->property("contentType").toString();
-}
-
-NetworkAccessManager *WebPage::networkAccessManager() {
-  return qobject_cast<NetworkAccessManager *>(QWebPage::networkAccessManager());
 }
 
 void WebPage::handleUnsupportedContent(QNetworkReply *reply) {

--- a/src/WebPage.h
+++ b/src/WebPage.h
@@ -8,7 +8,6 @@
 #include <QtNetwork>
 
 class WebPageManager;
-class NetworkAccessManager;
 class InvocationResult;
 class NetworkReplyProxy;
 
@@ -40,7 +39,6 @@ class WebPage : public QWebPage {
     QString getWindowName();
     bool matchesWindowSelector(QString);
     void setFocus();
-    NetworkAccessManager *networkAccessManager();
     void unsupportedContentFinishedReply(QNetworkReply *reply);
     QStringList pageHeaders();
     QByteArray body();

--- a/src/WebPageManager.cpp
+++ b/src/WebPageManager.cpp
@@ -1,6 +1,7 @@
 #include "WebPageManager.h"
 #include "WebPage.h"
 #include "NetworkCookieJar.h"
+#include "NetworkAccessManager.h"
 
 WebPageManager::WebPageManager(QObject *parent) : QObject(parent) {
   m_ignoreSslErrors = false;
@@ -9,7 +10,13 @@ WebPageManager::WebPageManager(QObject *parent) : QObject(parent) {
   m_loggingEnabled = false;
   m_ignoredOutput = new QFile(this);
   m_timeout = -1;
+  m_networkAccessManager = new NetworkAccessManager(this);
+  m_networkAccessManager->setCookieJar(m_cookieJar);
   createPage(this)->setFocus();
+}
+
+NetworkAccessManager *WebPageManager::networkAccessManager() {
+  return m_networkAccessManager;
 }
 
 void WebPageManager::append(WebPage *value) {
@@ -102,6 +109,7 @@ void WebPageManager::setTimeout(int timeout) {
 void WebPageManager::reset() {
   m_timeout = -1;
   m_cookieJar->clearCookies();
+  m_networkAccessManager->reset();
   m_pages.first()->deleteLater();
   m_pages.clear();
   createPage(this)->setFocus();

--- a/src/WebPageManager.h
+++ b/src/WebPageManager.h
@@ -9,6 +9,7 @@
 
 class WebPage;
 class NetworkCookieJar;
+class NetworkAccessManager;
 
 class WebPageManager : public QObject {
   Q_OBJECT
@@ -30,6 +31,7 @@ class WebPageManager : public QObject {
     QDebug logger() const;
     void enableLogging();
     void replyFinished(QNetworkReply *reply);
+    NetworkAccessManager *networkAccessManager();
 
   public slots:
     void emitLoadStarted();
@@ -54,6 +56,7 @@ class WebPageManager : public QObject {
     bool m_loggingEnabled;
     QFile *m_ignoredOutput;
     int m_timeout;
+    NetworkAccessManager *m_networkAccessManager;
 };
 
 #endif // _WEBPAGEMANAGER_H


### PR DESCRIPTION
Destroying the NetworkAccessManager seems to result in "terminate called
without an active exception" segfaults. The documentation states that an
application requires only a single single NetworkAccessManager.
