### PR TITLE
Upgrade selenium-webdriver gem to fix spec failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.2)
     appraisal (0.4.0)
       bundler
       rake
@@ -19,19 +18,16 @@ GEM
       rack-test (>= 0.5.4)
       selenium-webdriver (~> 2.0)
       xpath (~> 1.0.0)
-    childprocess (0.3.6)
-      ffi (~> 1.0, >= 1.0.6)
+    childprocess (0.3.9)
+      ffi (~> 1.0, >= 1.0.11)
     diff-lcs (1.1.2)
-    ffi (1.2.0)
-    ffi (1.2.0-x86-mingw32)
+    ffi (1.6.0)
+    ffi (1.6.0-x86-mingw32)
     json (1.7.7)
-    libwebsocket (0.1.7.1)
-      addressable
-      websocket
     mime-types (1.19)
     mini_magick (3.2.1)
       subexec (~> 0.0.4)
-    multi_json (1.5.0)
+    multi_json (1.7.2)
     nokogiri (1.5.6)
     nokogiri (1.5.6-x86-mingw32)
     rack (1.5.2)
@@ -49,18 +45,18 @@ GEM
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.6.0)
     rubyzip (0.9.9)
-    selenium-webdriver (2.27.2)
+    selenium-webdriver (2.31.0)
       childprocess (>= 0.2.5)
-      libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
+      websocket (~> 1.0.4)
     sinatra (1.3.5)
       rack (~> 1.4)
       rack-protection (~> 1.3)
       tilt (~> 1.3, >= 1.3.3)
     subexec (0.0.4)
     tilt (1.3.3)
-    websocket (1.0.6)
+    websocket (1.0.7)
     xpath (1.0.0)
       nokogiri (~> 1.3)
 


### PR DESCRIPTION
Currently it looks like there is one spec failing on vagrant environment. This should fix the spec failure which says it is _unable to obtain stable firefox connection in 60 seconds_. Please see similar problem at http://stackoverflow.com/questions/14303161/unable-to-obtain-stable-firefox-connection-in-60-seconds-127-0-0-17055
