### PR TITLE
Suggest use of the xvfb-run utility in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ CI
 
 If you're like us, you'll be using capybara-webkit on CI.
 
-On Linux platforms, capybara-webkit requires an X server to run, although it doesn't create any visible windows. Xvfb works fine for this. You can setup Xvfb yourself and set a DISPLAY variable, or try out the [headless gem](https://github.com/leonid-shevtsov/headless).
+On Linux platforms, capybara-webkit requires an X server to run, although it doesn't create any visible windows. Xvfb works fine for this. You can setup Xvfb yourself and set a DISPLAY variable, try out the [headless gem](https://github.com/leonid-shevtsov/headless), or use the xvfb-run utility as follows:
+
+```
+xvfb-run -a bundle exec spec
+```
+
+This automatically sets up a virtual X server on a free server number.
 
 Usage
 -----


### PR DESCRIPTION
I've found [xvfb-run](http://manpages.ubuntu.com/manpages/natty/man1/xvfb-run.1.html) to be the easiest way of using capybara-webkit in a CI environment, so it might be nice to add it to the README.
