### PR TITLE
Warn user if he using old json version (related #1020)

### DIFF
--- a/lib/capybara/webkit/browser.rb
+++ b/lib/capybara/webkit/browser.rb
@@ -4,6 +4,7 @@ module Capybara::Webkit
   class Browser
     def initialize(connection)
       @connection = connection
+      check_json_version
     end
 
     def authenticate(username, password)
@@ -204,6 +205,12 @@ module Capybara::Webkit
     end
 
     private
+
+    def check_json_version
+      if Gem::Version.new(JSON::VERSION) < Gem::Version.new('1.6.0')
+        warn "[WARNING] Your json gem is outdated. You should use at least '~> 1.6.0' in order to see capybara-webkit error messages correctly."
+      end
+    end
 
     def check
       result = @connection.gets

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -7,7 +7,8 @@ require 'base64'
 
 describe Capybara::Webkit::Browser do
 
-  let(:browser) { Capybara::Webkit::Browser.new(Capybara::Webkit::Connection.new) }
+  let(:connection) { Capybara::Webkit::Connection.new }
+  let(:browser) { Capybara::Webkit::Browser.new(connection) }
   let(:browser_ignore_ssl_err) do
     Capybara::Webkit::Browser.new(Capybara::Webkit::Connection.new).tap do |browser|
       browser.ignore_ssl_errors
@@ -257,5 +258,19 @@ describe Capybara::Webkit::Browser do
     browser = Capybara::Webkit::Browser.new(connection)
 
     expect { browser.visit("/") }.not_to raise_error(/empty response/)
+  end
+
+  describe '#command' do
+    context 'non-ok response' do
+      it 'raises an error of given class' do
+        error_json = '{"json_class": "Capybara::Webkit::InvalidResponseError"}'
+
+        connection.should_receive(:gets).ordered.and_return 'error'
+        connection.should_receive(:gets).ordered.and_return error_json.bytesize
+        connection.stub read: error_json
+
+        expect { browser.command 'blah', 'meh' }.to raise_error(Capybara::Webkit::InvalidResponseError)
+      end
+    end
   end
 end


### PR DESCRIPTION
Related: https://github.com/jnicklas/capybara/issues/1020

Not sure if it worth to add appraisals with different json versions and actually add a compatibility code instead of warning.
