### PR TITLE
Fail immediately when trying to compile with less than Qt 4.8

### DIFF
--- a/src/webkit_server.pro
+++ b/src/webkit_server.pro
@@ -135,6 +135,11 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 } else {
   QT += webkit
 }
+lessThan(QT_MAJOR_VERSION, 5) {
+  lessThan(QT_MINOR_VERSION, 8) {
+    error(At least Qt 4.8.0 is required to run capybara-webkit.)
+  }
+}
 CONFIG += console precompile_header
 CONFIG -= app_bundle
 PRECOMPILED_HEADER = stable.h


### PR DESCRIPTION
- Add a Qt version assertion to main.cpp
- Move main.cpp to the top of the sources list so it compiles early
