### PR TITLE
Bug when visiting a page with params that contains square brackets

### DIFF
--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -52,6 +52,30 @@ describe Capybara::Session do
     end
   end
 
+  context "visiting with params with a square bracket" do
+    before(:all) do
+      @app = lambda do |env|
+        body = <<-HTML
+          <html><body>
+            Hello
+          </body></html>
+        HTML
+        [200,
+          { 'Content-Type' => 'text/html; charset=UTF-8', 'Content-Length' => body.length.to_s },
+          [body]]
+      end
+    end
+
+    before do
+      subject.visit "/test[with_brackets]=true"
+      #subject.visit "/testwith_nobrackets=true"    # Toggle this line to see it pass.
+    end
+
+    it "visits the page", wip: true do
+      subject.should have_content('Hello')
+    end
+  end
+
   context "simple app" do
     before(:all) do
       @app = lambda do |env|


### PR DESCRIPTION
When I visit a page with square brackets in the params of the url like `/foo?bar[baz]=true`
Then I should see that page

Instead, the request is never sent.

Traced this as far as `lib/capybara/webkit/browser.rb:145` in the `command` method.

Run with the following:

```
rspec spec/integration/session_spec.rb --tag wip
```

found this with @coffeencoke
