### PR TITLE
Silence debug messages from Qt

### DIFF
--- a/src/WebPageManager.cpp
+++ b/src/WebPageManager.cpp
@@ -130,10 +130,11 @@ bool WebPageManager::isLoading() const {
 }
 
 QDebug WebPageManager::logger() const {
-  if (m_loggingEnabled)
-    return qDebug();
-  else
+  if (m_loggingEnabled) {
+    return qCritical();
+  } else {
     return QDebug(m_ignoredOutput);
+  }
 }
 
 void WebPageManager::enableLogging() {


### PR DESCRIPTION
- 99% of the messages we see are useless
- Debug output is driving OS X users nuts
