### PR TITLE
Throw an informative error if Qt is not present

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -1,9 +1,2 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "lib", "capybara_webkit_builder")
-
-if system("qmake").nil?
-  error = "Couldn't find the 'qmake' executable. Please install Qt and then proceed."
-
-  raise(error)
-else
-  CapybaraWebkitBuilder.build_all
-end
+CapybaraWebkitBuilder.build_all

--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -83,6 +83,13 @@ module CapybaraWebkitBuilder
   end
 
   def build_all
+    error = <<-EOS
+      Couldn't find the 'qmake' executable. Please install Qt and then proceed.
+
+      Refer this webpage https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit
+    EOS
+
+    raise(error)
     makefile &&
     qmake &&
     build &&


### PR DESCRIPTION
Right now, running "gem install capybara-webkit" on a machine that
doesn't have Qt binaries installed fails with the
message "'qmake -spec macs-g++' not available". This change will check
if a binary is installed and throw a descriptive error.

Fixes #590
