### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Capybara.javascript_driver = :webkit
 
 In cucumber, tag scenarios with @javascript to run them using a headless WebKit browser.
 
-In RSpec, use the `:js => true` flag. See the [capybara documention](http://rubydoc.info/gems/capybara#Using_Capybara_with_RSpec) for more information about using capybara with RSpec.
+In RSpec, use the `:js => true` flag. See the [capybara documentation](http://rubydoc.info/gems/capybara#Using_Capybara_with_RSpec) for more information about using capybara with RSpec.
 
 Take note of the transactional fixtures section of the [capybara README](https://github.com/jnicklas/capybara/blob/master/README.md).
 


### PR DESCRIPTION
"capybara documentation" instead of "capybara documention"
