### PR TITLE
Fix killing webkit_server on JRuby

### DIFF
--- a/lib/capybara/webkit/connection.rb
+++ b/lib/capybara/webkit/connection.rb
@@ -47,12 +47,12 @@ module Capybara::Webkit
     def start_server
       open_pipe
       discover_port
+      discover_pid
       forward_output_in_background_thread
     end
 
     def open_pipe
-      _, @pipe_stdout, @pipe_stderr, wait_thr = Open3.popen3(SERVER_PATH)
-      @pid = wait_thr[:pid]
+      _, @pipe_stdout, @pipe_stderr, @wait_thr = Open3.popen3(SERVER_PATH)
       register_shutdown_hook
     end
 
@@ -79,6 +79,10 @@ module Capybara::Webkit
       if IO.select([@pipe_stdout], nil, nil, WEBKIT_SERVER_START_TIMEOUT)
         @port = ((@pipe_stdout.first || '').match(/listening on port: (\d+)/) || [])[1].to_i
       end
+    end
+
+    def discover_pid
+      @pid = @wait_thr[:pid]
     end
 
     def forward_output_in_background_thread


### PR DESCRIPTION
The connection now waits until `webkit_server` has started so that it can discover the pid.

We have not added any additional tests as the current suite has plenty of failures which capture this problem. We have not fixed the rest of the failing tests on JRuby, but at least with this patch you should no longer so the following error.

```
TypeError: no implicit conversion from nil to integer
                    kill at org/jruby/RubyProcess.java:971
                    kill at org/jruby/RubyProcess.java:886
            kill_process at /Users/pivotal/workspace/capybara-webkit/lib/capybara/webkit/connection.rb:73
  register_shutdown_hook at /Users/pivotal/workspace/capybara-webkit/lib/capybara/webkit/connection.rb:64
```
