### PR TITLE
Fix build on Travis

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'bundler'
 require 'rspec/core/rake_task'
-require 'capybara_webkit_builder'
+require_relative './lib/capybara_webkit_builder'
 require 'appraisal'
 
 Bundler::GemHelper.install_tasks


### PR DESCRIPTION
Use require_relative for capybara_webkit_builder as RVM on travis doesn't include lib directory in require paths
