### PR TITLE
Close connection explicitly in test

### DIFF
--- a/spec/support/matchers/include_response.rb
+++ b/spec/support/matchers/include_response.rb
@@ -1,0 +1,25 @@
+RSpec::Matchers.define :include_response do |expected_response|
+  read_timeout = 2
+  read_bytes = 4096
+  timeout_status = nil
+  response = ""
+
+  match do |read_io|
+    found_response = false
+
+    while !found_response && IO.select([read_io], nil, nil, read_timeout) do
+      response += read_io.read_nonblock(read_bytes)
+      found_response = response.include?(expected_response)
+    end
+
+    found_response
+  end
+
+  failure_message_for_should do |actual|
+    "expected #{response} to include #{expected_response}"
+  end
+
+  failure_message_for_should_not do |actual|
+    "expected #{response} to not include #{expected_response}"
+  end
+end


### PR DESCRIPTION
This fixes a stderr redirection test on fast machines. The write pipe was getting closed before the redirection thread had a chance to copy it's contents into it. This affects multiple versions of ruby. We were seeing it on MRI 2.1.0 & JRuby 1.7.9.

The connection should always be explicitly closed in every test. This will ensure that threads don't live beyond the immediate test. I have only done this for the [connection spec](https://github.com/rupurt/capybara-webkit/blob/close-connection-explicitly/spec/connection_spec.rb), though this should be done throughout the entire suite eventually.
