### PR TITLE
Fixe stderr redirection test

### DIFF
--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -19,18 +19,18 @@ describe Capybara::Webkit::Connection do
   end
 
   it 'forwards stderr to the given IO object' do
-    read, write = IO.pipe
-    redirected_connection = Capybara::Webkit::Connection.new(:stderr => write)
-    script = 'console.log("hello world")'
+    read_io, write_io = IO.pipe
+    redirected_connection = Capybara::Webkit::Connection.new(:stderr => write_io)
     redirected_connection.puts "EnableLogging"
     redirected_connection.puts 0
+
+    script = 'console.log("hello world")'
     redirected_connection.puts "Execute"
     redirected_connection.puts 1
     redirected_connection.puts script.to_s.bytesize
     redirected_connection.print script
-    sleep(0.5)
-    write.close
-    read.read.should =~ /hello world $/
+
+    expect(read_io).to include_response "hello world \n"
   end
 
   it 'does not forward stderr to nil' do

--- a/spec/support/matchers/include_response.rb
+++ b/spec/support/matchers/include_response.rb
@@ -1,0 +1,24 @@
+RSpec::Matchers.define :include_response do |expected_response|
+  read_timeout = 2
+  read_bytes = 4096
+  response = ""
+
+  match do |read_io|
+    found_response = false
+
+    while !found_response && IO.select([read_io], nil, nil, read_timeout) do
+      response += read_io.read_nonblock(read_bytes)
+      found_response = response.include?(expected_response)
+    end
+
+    found_response
+  end
+
+  failure_message_for_should do |actual|
+    "expected #{response} to include #{expected_response}"
+  end
+
+  failure_message_for_should_not do |actual|
+    "expected #{response} to not include #{expected_response}"
+  end
+end


### PR DESCRIPTION
This fixes a stderr redirection test on fast machines. The write pipe was getting closed before the redirection thread had a chance to copy its contents into it. This affects multiple versions of ruby. We were seeing it on MRI 2.1.0 & JRuby 1.7.9.

This PR was broken out from #617
