### PR TITLE
Post screenshots to S3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     capybara-webkit (1.1.1)
+      aws-sdk
       capybara (>= 2.0.2, < 2.2.0)
       json
 
@@ -11,6 +12,10 @@ GEM
     appraisal (0.4.0)
       bundler
       rake
+    aws-sdk (1.38.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+      uuidtools (~> 2.1)
     capybara (2.1.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -25,16 +30,16 @@ GEM
     ffi (1.9.3-x86-mingw32)
     json (1.8.1)
     json (1.8.1-java)
-    mime-types (2.0)
+    mime-types (2.2)
     mini_magick (3.2.1)
       subexec (~> 0.0.4)
-    mini_portile (0.5.2)
+    mini_portile (0.5.3)
     multi_json (1.8.4)
-    nokogiri (1.6.0)
+    nokogiri (1.6.1)
       mini_portile (~> 0.5.0)
-    nokogiri (1.6.0-java)
+    nokogiri (1.6.1-java)
       mini_portile (~> 0.5.0)
-    nokogiri (1.6.0-x86-mingw32)
+    nokogiri (1.6.1-x86-mingw32)
       mini_portile (~> 0.5.0)
     rack (1.5.2)
     rack-protection (1.3.2)
@@ -62,6 +67,7 @@ GEM
       tilt (~> 1.3, >= 1.3.3)
     subexec (0.0.4)
     tilt (1.3.3)
+    uuidtools (2.1.4)
     websocket (1.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ If you're like us, you'll be using capybara-webkit on CI.
 
 On Linux platforms, capybara-webkit requires an X server to run, although it doesn't create any visible windows. Xvfb works fine for this. You can setup Xvfb yourself and set a DISPLAY variable, or try out the [headless gem](https://github.com/leonid-shevtsov/headless).
 
+You can post screenshots taken in CI to an Amazon S3 bucket. Set the bucket name using the environment variable `CAPYBARA_WEBKIT_S3_SCREENSHOTS_BUCKET`. Specify your AWS credentials using `CAPYBARA_WEBKIT_S3_ACCESS_KEY_ID` and `CAPYBARA_WEBKIT_S3_SECRET_ACCESS_KEY`.
+
 Usage
 -----
 

--- a/capybara-webkit.gemspec
+++ b/capybara-webkit.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("capybara", ">= 2.0.2", "< 2.2.0")
   s.add_runtime_dependency("json")
+  s.add_runtime_dependency("aws-sdk")
 
   s.add_development_dependency("rspec", "~> 2.14.0")
   # Sinatra is used by Capybara's TestApp


### PR DESCRIPTION
When screenshots are taken in CI environments, the files are saved to
temporary directories and are not accessible. This commit allows the
posting of screenshots to an S3 bucket so that they can be accessed
after CI builds.

Posting to S3 will happen automatically for screenshots if the
environment variable `CAPYBARA_WEBKIT_S3_SCREENSHOTS_BUCKET` is set.