### PR TITLE
Trigger a change event when clearing a text input

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -1130,6 +1130,11 @@ describe Capybara::Webkit::Driver do
         driver.find_xpath("//input[@type='#{field_type}']").first.set(newtext)
         driver.find_xpath("//li").map(&:visible_text).should eq keyevents
       end
+
+      it "triggers change events when emptying inputs of type #{field_type}" do
+        driver.find_xpath("//input[@type='#{field_type}']").first.set('')
+        driver.find_xpath("//li").map(&:visible_text).should eq %w(focus change)
+      end
     end
 
     it "triggers textarea input events" do

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -286,6 +286,9 @@ Capybara = {
         CapybaraInvocation.keypress(value[strindex]);
       }
 
+      if (length === 0)
+        this.trigger(index, 'change');
+
     } else if (type === "checkbox" || type === "radio") {
       if (node.checked != (value === "true")) {
         this.leftClick(index);


### PR DESCRIPTION
At present, if a test attempts to clear an input, and then make an
assertion, no code is informed of the change, as the only event
triggered is `focus`. Triggering a `change` event should allow code to
work properly in these cases.

Perhaps one other solution would be to trigger a keydown event with backspace?
