### PR TITLE
Convert specs to RSpec 2.14.4 syntax

### DIFF
--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -56,7 +56,7 @@ describe Capybara::Webkit::Browser do
     end
 
     it "doesn't accept a self-signed certificate by default" do
-      lambda { browser.visit "https://#{@host}:#{@port}/" }.should raise_error
+      expect { browser.visit "https://#{@host}:#{@port}/" }.to raise_error
     end
 
     it 'accepts a self-signed certificate if configured to do so' do
@@ -66,7 +66,7 @@ describe Capybara::Webkit::Browser do
     it "doesn't accept a self-signed certificate in a new window by default" do
       browser.execute_script("window.open('about:blank')")
       browser.window_focus(browser.get_window_handles.last)
-      lambda { browser.visit "https://#{@host}:#{@port}/" }.should raise_error
+      expect { browser.visit "https://#{@host}:#{@port}/" }.to raise_error
     end
 
     it 'accepts a self-signed certificate in a new window if configured to do so' do
@@ -129,22 +129,22 @@ describe Capybara::Webkit::Browser do
 
     it "should load images in image tags by default" do
       browser.visit("http://#{@host}:#{@port}/")
-      @received_requests.find {|r| r =~ %r{/path/to/image}   }.should_not be_nil
+      expect(@received_requests.find {|r| r =~ %r{/path/to/image}   }).not_to be_nil
     end
 
     it "should load images in css by default" do
       browser.visit("http://#{@host}:#{@port}/")
-      @received_requests.find {|r| r =~ %r{/path/to/image}   }.should_not be_nil
+      expect(@received_requests.find {|r| r =~ %r{/path/to/image}   }).not_to be_nil
     end
 
     it "should not load images in image tags when skip_image_loading is true" do
       browser_skip_images.visit("http://#{@host}:#{@port}/")
-      @received_requests.find {|r| r =~ %r{/path/to/image} }.should be_nil
+      expect(@received_requests.find {|r| r =~ %r{/path/to/image} }).to be_nil
     end
 
     it "should not load images in css when skip_image_loading is true" do
       browser_skip_images.visit("http://#{@host}:#{@port}/")
-      @received_requests.find {|r| r =~ %r{/path/to/bgimage} }.should be_nil
+      expect(@received_requests.find {|r| r =~ %r{/path/to/bgimage} }).to be_nil
     end
   end
 
@@ -202,7 +202,7 @@ describe Capybara::Webkit::Browser do
                         :user => @user,
                         :pass => @pass)
       browser.visit @url
-      @proxy_requests.size.should eq 2
+      expect(@proxy_requests.size).to eq 2
       @request = @proxy_requests[-1]
     end
 
@@ -212,48 +212,48 @@ describe Capybara::Webkit::Browser do
     end
 
     it 'uses the HTTP proxy correctly' do
-      @request[0].should match(/^GET\s+http:\/\/example.org\/\s+HTTP/i)
-      @request.find { |header|
-        header =~ /^Host:\s+example.org$/i }.should_not be nil
+      expect(@request[0]).to match(/^GET\s+http:\/\/example.org\/\s+HTTP/i)
+      expect(@request.find { |header|
+        header =~ /^Host:\s+example.org$/i }).not_to be nil
     end
 
     it 'sends correct proxy authentication' do
       auth_header = @request.find { |header|
         header =~ /^Proxy-Authorization:\s+/i }
-      auth_header.should_not be nil
+      expect(auth_header).not_to be nil
 
       user, pass = Base64.decode64(auth_header.split(/\s+/)[-1]).split(":")
-      user.should eq @user
-      pass.should eq @pass
+      expect(user).to eq @user
+      expect(pass).to eq @pass
     end
 
     it "uses the proxies' response" do
-      browser.body.should include "D'oh!"
+      expect(browser.body).to include "D'oh!"
     end
 
     it 'uses original URL' do
-      browser.current_url.should eq @url
+      expect(browser.current_url).to eq @url
     end
 
     it 'uses URLs changed by javascript' do
       browser.execute_script "window.history.pushState('', '', '/blah')"
-      browser.current_url.should eq 'http://example.org/blah'
+      expect(browser.current_url).to eq 'http://example.org/blah'
     end
 
     it 'is possible to disable proxy again' do
       @proxy_requests.clear
       browser.clear_proxy
       browser.visit "http://#{@host}:#{@port}/"
-      @proxy_requests.size.should eq 0
+      expect(@proxy_requests.size).to eq 0
     end
   end
 
   it "doesn't try to read an empty response" do
     connection = double("connection")
-    connection.stub(:puts)
-    connection.stub(:print)
-    connection.stub(:gets).and_return("ok\n", "0\n")
-    connection.stub(:read).and_raise(StandardError.new("tried to read empty response"))
+    allow(connection).to receive(:puts)
+    allow(connection).to receive(:print)
+    allow(connection).to receive(:gets).and_return("ok\n", "0\n")
+    allow(connection).to receive(:read).and_raise(StandardError.new("tried to read empty response"))
 
     browser = Capybara::Webkit::Browser.new(connection)
 
@@ -265,8 +265,8 @@ describe Capybara::Webkit::Browser do
       it 'raises an error of given class' do
         error_json = '{"class": "ClickFailed"}'
 
-        connection.should_receive(:gets).ordered.and_return 'error'
-        connection.should_receive(:gets).ordered.and_return error_json.bytesize
+        expect(connection).to receive(:gets).ordered.and_return 'error'
+        expect(connection).to receive(:gets).ordered.and_return error_json.bytesize
         connection.stub read: error_json
 
         expect { browser.command 'blah', 'meh' }.to raise_error(Capybara::Webkit::ClickFailed)

--- a/spec/capybara_webkit_builder_spec.rb
+++ b/spec/capybara_webkit_builder_spec.rb
@@ -6,37 +6,37 @@ describe CapybaraWebkitBuilder do
 
   it "will use the env variable for #make_bin" do
     with_env_vars("MAKE" => "fake_make") do
-      builder.make_bin.should == "fake_make"
+      expect(builder.make_bin).to eq("fake_make")
     end
   end
 
   it "will use the env variable for #qmake_bin" do
     with_env_vars("QMAKE" => "fake_qmake") do
-      builder.qmake_bin.should == "fake_qmake"
+      expect(builder.qmake_bin).to eq("fake_qmake")
     end
   end
 
   it "will use the env variable for #os_spec" do
     with_env_vars("SPEC" => "fake_os_spec") do
-      builder.spec.should == "fake_os_spec"
+      expect(builder.spec).to eq("fake_os_spec")
     end
   end
 
   it "defaults the #make_bin" do
     with_env_vars("MAKE_BIN" => nil) do
-      builder.make_bin.should == 'make'
+      expect(builder.make_bin).to eq('make')
     end
   end
 
   it "defaults the #qmake_bin" do
     with_env_vars("QMAKE" => nil) do
-      builder.qmake_bin.should == 'qmake'
+      expect(builder.qmake_bin).to eq('qmake')
     end
   end
 
   it "defaults #spec to the #os_specs" do
     with_env_vars("SPEC" => nil) do
-      builder.spec.should == builder.os_spec
+      expect(builder.spec).to eq(builder.os_spec)
     end
   end
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -8,14 +8,14 @@ describe Capybara::Webkit::Connection do
     connection.puts 1
     connection.puts url.to_s.bytesize
     connection.print url
-    connection.gets.should eq "ok\n"
-    connection.gets.should eq "0\n"
+    expect(connection.gets).to eq "ok\n"
+    expect(connection.gets).to eq "0\n"
     connection.puts "Body"
     connection.puts 0
-    connection.gets.should eq "ok\n"
+    expect(connection.gets).to eq "ok\n"
     response_length = connection.gets.to_i
     response = connection.read(response_length)
-    response.should include("Hey there")
+    expect(response).to include("Hey there")
   end
 
   it 'forwards stderr to the given IO object' do
@@ -34,39 +34,39 @@ describe Capybara::Webkit::Connection do
   end
 
   it 'does not forward stderr to nil' do
-    IO.should_not_receive(:copy_stream)
+    expect(IO).not_to receive(:copy_stream)
     Capybara::Webkit::Connection.new(:stderr => nil)
   end
 
   it 'prints a deprecation warning if the stdout option is used' do
-    Capybara::Webkit::Connection.any_instance.should_receive(:warn)
+    expect_any_instance_of(Capybara::Webkit::Connection).to receive(:warn)
     Capybara::Webkit::Connection.new(:stdout => nil)
   end
 
   it 'does not forward stdout to nil if the stdout option is used' do
-    Capybara::Webkit::Connection.any_instance.stub(:warn)
-    IO.should_not_receive(:copy_stream)
+    allow_any_instance_of(Capybara::Webkit::Connection).to receive(:warn)
+    expect(IO).not_to receive(:copy_stream)
     Capybara::Webkit::Connection.new(:stdout => nil)
   end
 
   it "returns the server port" do
-    connection.port.should be_between 0x400, 0xffff
+    expect(connection.port).to be_between 0x400, 0xffff
   end
 
   it 'sets appropriate options on its socket' do
     socket = double('socket')
-    TCPSocket.stub(:open).and_return(socket)
+    allow(TCPSocket).to receive(:open).and_return(socket)
     if defined?(Socket::TCP_NODELAY)
-      socket.should_receive(:setsockopt).with(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, true)
+      expect(socket).to receive(:setsockopt).with(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, true)
     else
-      socket.should_not_receive(:setsockopt)
+      expect(socket).not_to receive(:setsockopt)
     end
     Capybara::Webkit::Connection.new
   end
 
   it "chooses a new port number for a new connection" do
     new_connection = Capybara::Webkit::Connection.new
-    new_connection.port.should_not == connection.port
+    expect(new_connection.port).not_to eq(connection.port)
   end
 
   let(:connection) { Capybara::Webkit::Connection.new }

--- a/spec/cookie_jar_spec.rb
+++ b/spec/cookie_jar_spec.rb
@@ -4,7 +4,7 @@ require 'capybara/webkit/cookie_jar'
 describe Capybara::Webkit::CookieJar do
   let(:browser) {
     browser = double("Browser")
-    browser.stub(:get_cookies) { [
+    allow(browser).to receive(:get_cookies) { [
         "cookie1=1; domain=.example.org; path=/",
         "cookie1=2; domain=.example.org; path=/dir1/",
         "cookie1=3; domain=.facebook.com; path=/",
@@ -17,32 +17,32 @@ describe Capybara::Webkit::CookieJar do
 
   describe "#find" do
     it "returns a cookie object" do
-      subject.find("cookie1", "www.facebook.com").domain.should eq ".facebook.com"
+      expect(subject.find("cookie1", "www.facebook.com").domain).to eq ".facebook.com"
     end
 
     it "returns the right cookie for every given domain/path" do
-      subject.find("cookie1", "example.org").value.should eq "1"
-      subject.find("cookie1", "www.facebook.com").value.should eq "3"
-      subject.find("cookie2", "sub1.example.org").value.should eq "4"
+      expect(subject.find("cookie1", "example.org").value).to eq "1"
+      expect(subject.find("cookie1", "www.facebook.com").value).to eq "3"
+      expect(subject.find("cookie2", "sub1.example.org").value).to eq "4"
     end
 
     it "does not return a cookie from other domain" do
-      subject.find("cookie2", "www.example.org").should eq nil
+      expect(subject.find("cookie2", "www.example.org")).to eq nil
     end
 
     it "respects path precedence rules" do
-      subject.find("cookie1", "www.example.org").value.should eq "1"
-      subject.find("cookie1", "www.example.org", "/dir1/123").value.should eq "2"
+      expect(subject.find("cookie1", "www.example.org").value).to eq "1"
+      expect(subject.find("cookie1", "www.example.org", "/dir1/123").value).to eq "2"
     end
   end
 
   describe "#[]" do
     it "returns the first matching cookie's value" do
-      subject["cookie1", "example.org"].should eq "1"
+      expect(subject["cookie1", "example.org"]).to eq "1"
     end
 
     it "returns nil if no cookie is found" do
-      subject["notexisting"].should eq nil
+      expect(subject["notexisting"]).to eq nil
     end
   end
 end

--- a/spec/driver_rendering_spec.rb
+++ b/spec/driver_rendering_spec.rb
@@ -34,16 +34,16 @@ describe Capybara::Webkit::Driver, "rendering an image" do
     before { render({}) }
 
     it "should be a PNG" do
-      @image[:format].should eq "PNG"
+      expect(@image[:format]).to eq "PNG"
     end
 
     it "width default to 1000px (with 15px less for the scrollbar)" do
-      @image[:width].should be < 1001
-      @image[:width].should be > 1000-17
+      expect(@image[:width]).to be < 1001
+      expect(@image[:width]).to be > 1000-17
     end
 
     it "height should be at least 10px" do
-      @image[:height].should be >= 10
+      expect(@image[:height]).to be >= 10
     end
   end
 
@@ -51,16 +51,16 @@ describe Capybara::Webkit::Driver, "rendering an image" do
     before { render(:width => 500, :height => 400) }
 
     it "width should match the width given" do
-      @image[:width].should eq 500
+      expect(@image[:width]).to eq 500
     end
 
     it "height should match the height given" do
-      @image[:height].should eq 400
+      expect(@image[:height]).to eq 400
     end
 
     it "should reset window dimensions to their default value" do
-      driver.evaluate_script('window.innerWidth').should eq 1680
-      driver.evaluate_script('window.innerHeight').should eq 1050
+      expect(driver.evaluate_script('window.innerWidth')).to eq 1680
+      expect(driver.evaluate_script('window.innerHeight')).to eq 1050
     end
   end
 
@@ -68,16 +68,16 @@ describe Capybara::Webkit::Driver, "rendering an image" do
     before { render(:width => 50, :height => 10) }
 
     it "width should be greater than the width given" do
-      @image[:width].should be > 50
+      expect(@image[:width]).to be > 50
     end
 
     it "height should be greater than the height given" do
-      @image[:height].should be > 10
+      expect(@image[:height]).to be > 10
     end
 
     it "should restore viewport dimensions after rendering" do
-      driver.evaluate_script('window.innerWidth').should eq 1680
-      driver.evaluate_script('window.innerHeight').should eq 1050
+      expect(driver.evaluate_script('window.innerWidth')).to eq 1680
+      expect(driver.evaluate_script('window.innerHeight')).to eq 1050
     end
   end
 
@@ -86,8 +86,8 @@ describe Capybara::Webkit::Driver, "rendering an image" do
 
     it "should restore viewport dimensions after rendering" do
       render({})
-      driver.evaluate_script('window.innerWidth').should eq 800
-      driver.evaluate_script('window.innerHeight').should eq 600
+      expect(driver.evaluate_script('window.innerWidth')).to eq 800
+      expect(driver.evaluate_script('window.innerHeight')).to eq 600
     end
   end
 

--- a/spec/driver_resize_window_spec.rb
+++ b/spec/driver_resize_window_spec.rb
@@ -27,22 +27,22 @@ describe Capybara::Webkit::Driver, "#resize_window(width, height)" do
     driver.visit("#{AppRunner.app_host}/")
 
     driver.resize_window(800, 600)
-    driver.html.should include("[800x600]")
+    expect(driver.html).to include("[800x600]")
 
     driver.resize_window(300, 100)
-    driver.html.should include("[300x100]")
+    expect(driver.html).to include("[300x100]")
   end
 
   it "resizes the window to the specified size even before the document has loaded" do
     driver.resize_window(800, 600)
     driver.visit("#{AppRunner.app_host}/")
-    driver.html.should include("[800x600]")
+    expect(driver.html).to include("[800x600]")
   end
 
   it "resets the window to the default size when the driver is reset" do
     driver.resize_window(800, 600)
     driver.reset!
     driver.visit("#{AppRunner.app_host}/")
-    driver.html.should include(DEFAULT_DIMENTIONS)
+    expect(driver.html).to include(DEFAULT_DIMENTIONS)
   end
 end

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -63,13 +63,13 @@ describe Capybara::Webkit::Driver do
 
     it "finds frames by index" do
       driver.within_frame(0) do
-        driver.find_xpath("//*[contains(., 'goodbye')]").should_not be_empty
+        expect(driver.find_xpath("//*[contains(., 'goodbye')]")).not_to be_empty
       end
     end
 
     it "finds frames by id" do
       driver.within_frame("f") do
-        driver.find_xpath("//*[contains(., 'goodbye')]").should_not be_empty
+        expect(driver.find_xpath("//*[contains(., 'goodbye')]")).not_to be_empty
       end
     end
 
@@ -77,7 +77,7 @@ describe Capybara::Webkit::Driver do
       frame = driver.find_xpath('//iframe').first
       element = double(Capybara::Node::Base, base: frame)
       driver.within_frame(element) do
-        driver.find_xpath("//*[contains(., 'goodbye')]").should_not be_empty
+        expect(driver.find_xpath("//*[contains(., 'goodbye')]")).not_to be_empty
       end
     end
 
@@ -93,42 +93,42 @@ describe Capybara::Webkit::Driver do
 
     it "returns an attribute's value" do
       driver.within_frame("f") do
-        driver.find_xpath("//p").first["id"].should eq "farewell"
+        expect(driver.find_xpath("//p").first["id"]).to eq "farewell"
       end
     end
 
     it "returns an attribute's innerHTML" do
-      driver.find_xpath('//body').first.inner_html.should =~ %r{<iframe.*</iframe>.*<script.*</script>.*}m
+      expect(driver.find_xpath('//body').first.inner_html).to match(%r{<iframe.*</iframe>.*<script.*</script>.*}m)
     end
 
     it "receive an attribute's innerHTML" do
       driver.find_xpath('//body').first.inner_html = 'foobar'
-      driver.find_xpath("//body[contains(., 'foobar')]").should_not be_empty
+      expect(driver.find_xpath("//body[contains(., 'foobar')]")).not_to be_empty
     end
 
     it "returns a node's text" do
       driver.within_frame("f") do
-        driver.find_xpath("//p").first.visible_text.should eq "goodbye"
+        expect(driver.find_xpath("//p").first.visible_text).to eq "goodbye"
       end
     end
 
     it "returns the current URL" do
       driver.within_frame("f") do
-        driver.current_url.should eq driver_url(driver, "/iframe")
+        expect(driver.current_url).to eq driver_url(driver, "/iframe")
       end
     end
 
     it "evaluates Javascript" do
       driver.within_frame("f") do
         result = driver.evaluate_script(%<document.getElementById('farewell').innerText>)
-        result.should eq "goodbye"
+        expect(result).to eq "goodbye"
       end
     end
 
     it "executes Javascript" do
       driver.within_frame("f") do
         driver.execute_script(%<document.getElementById('farewell').innerHTML = 'yo'>)
-        driver.find_xpath("//p[contains(., 'yo')]").should_not be_empty
+        expect(driver.find_xpath("//p[contains(., 'yo')]")).not_to be_empty
       end
     end
 
@@ -137,24 +137,24 @@ describe Capybara::Webkit::Driver do
 
       driver.within_frame("f") {}
 
-      driver.current_url.should eq original_url
+      expect(driver.current_url).to eq original_url
     end
 
     it "returns the headers for the page" do
       driver.within_frame("f") do
-        driver.response_headers['X-Redirected'].should eq "true"
+        expect(driver.response_headers['X-Redirected']).to eq "true"
       end
     end
 
     it "returns the status code for the page" do
       driver.within_frame("f") do
-        driver.status_code.should eq 200
+        expect(driver.status_code).to eq 200
       end
     end
 
     it "returns the document title" do
       driver.within_frame("f") do
-        driver.title.should eq "Title"
+        expect(driver.title).to eq "Title"
       end
     end
   end
@@ -223,35 +223,35 @@ describe Capybara::Webkit::Driver do
     it "should redirect without content type" do
       visit("/form")
       driver.find_xpath("//input").first.click
-      driver.find_xpath("//p").first.visible_text.should eq ""
+      expect(driver.find_xpath("//p").first.visible_text).to eq ""
     end
 
     it "returns the current URL when changed by pushState after a redirect" do
       visit("/redirect-me")
-      driver.current_url.should eq driver_url(driver, "/target")
+      expect(driver.current_url).to eq driver_url(driver, "/target")
       driver.execute_script("window.history.pushState({}, '', '/pushed-after-redirect')")
-      driver.current_url.should eq driver_url(driver, "/pushed-after-redirect")
+      expect(driver.current_url).to eq driver_url(driver, "/pushed-after-redirect")
     end
 
     it "returns the current URL when changed by replaceState after a redirect" do
       visit("/redirect-me")
-      driver.current_url.should eq driver_url(driver, "/target")
+      expect(driver.current_url).to eq driver_url(driver, "/target")
       driver.execute_script("window.history.replaceState({}, '', '/replaced-after-redirect')")
-      driver.current_url.should eq driver_url(driver, "/replaced-after-redirect")
+      expect(driver.current_url).to eq driver_url(driver, "/replaced-after-redirect")
     end
 
     it "should make headers available through response_headers" do
       visit('/redirect-me')
-      driver.response_headers['X-Redirected'].should eq "true"
+      expect(driver.response_headers['X-Redirected']).to eq "true"
       visit('/target')
-      driver.response_headers['X-Redirected'].should eq "false"
+      expect(driver.response_headers['X-Redirected']).to eq "false"
     end
 
     it "should make the status code available through status_code" do
       visit('/redirect-me')
-      driver.status_code.should eq 200
+      expect(driver.status_code).to eq 200
       visit('/target')
-      driver.status_code.should eq 200
+      expect(driver.status_code).to eq 200
     end
   end
 
@@ -268,15 +268,15 @@ describe Capybara::Webkit::Driver do
     before { visit("/") }
 
     it "renders unsupported content types gracefully" do
-      driver.html.should =~ /css/
+      expect(driver.html).to match(/css/)
     end
 
     it "sets the response headers with respect to the unsupported request" do
-      driver.response_headers["Content-Type"].should eq "text/css"
+      expect(driver.response_headers["Content-Type"]).to eq "text/css"
     end
 
     it "does not wrap the content in HTML tags" do
-      driver.html.should_not =~ /<html>/
+      expect(driver.html).not_to match(/<html>/)
     end
   end
 
@@ -297,7 +297,7 @@ describe Capybara::Webkit::Driver do
     before { visit("/") }
 
     it "does not strip HTML tags" do
-      driver.html.should =~ /<html>/
+      expect(driver.html).to match(/<html>/)
     end
   end
 
@@ -315,7 +315,7 @@ describe Capybara::Webkit::Driver do
 
     it "should return the binary content" do
       src = driver.html.force_encoding('binary')
-      src.should eq "Hello\xFF\xFF\xFF\xFFWorld".force_encoding('binary')
+      expect(src).to eq "Hello\xFF\xFF\xFF\xFFWorld".force_encoding('binary')
     end
   end
 
@@ -355,23 +355,23 @@ describe Capybara::Webkit::Driver do
 
     it "handles anchor tags" do
       visit("#test")
-      driver.find_xpath("//*[contains(., 'hello')]").should_not be_empty
+      expect(driver.find_xpath("//*[contains(., 'hello')]")).not_to be_empty
       visit("#test")
-      driver.find_xpath("//*[contains(., 'hello')]").should_not be_empty
+      expect(driver.find_xpath("//*[contains(., 'hello')]")).not_to be_empty
     end
 
     it "finds content after loading a URL" do
-      driver.find_xpath("//*[contains(., 'hello')]").should_not be_empty
+      expect(driver.find_xpath("//*[contains(., 'hello')]")).not_to be_empty
     end
 
     it "has an empty page after reseting" do
       driver.reset!
-      driver.find_xpath("//*[contains(., 'hello')]").should be_empty
+      expect(driver.find_xpath("//*[contains(., 'hello')]")).to be_empty
     end
 
     it "has a blank location after reseting" do
       driver.reset!
-      driver.current_url.should eq "about:blank"
+      expect(driver.current_url).to eq "about:blank"
     end
 
     it "raises an error for an invalid xpath query" do
@@ -385,114 +385,114 @@ describe Capybara::Webkit::Driver do
     end
 
     it "returns an attribute's value" do
-      driver.find_xpath("//p").first["id"].should eq "greeting"
+      expect(driver.find_xpath("//p").first["id"]).to eq "greeting"
     end
 
     it "parses xpath with quotes" do
-      driver.find_xpath('//*[contains(., "hello")]').should_not be_empty
+      expect(driver.find_xpath('//*[contains(., "hello")]')).not_to be_empty
     end
 
     it "returns a node's visible text" do
-      driver.find_xpath("//*[@id='hidden-text']").first.visible_text.should eq "Some of this text is"
+      expect(driver.find_xpath("//*[@id='hidden-text']").first.visible_text).to eq "Some of this text is"
     end
 
     it "normalizes a node's text" do
-      driver.find_xpath("//div[contains(@class, 'normalize')]").first.visible_text.should eq "Spaces not normalized"
+      expect(driver.find_xpath("//div[contains(@class, 'normalize')]").first.visible_text).to eq "Spaces not normalized"
     end
 
     it "returns all of a node's text" do
-      driver.find_xpath("//*[@id='hidden-text']").first.all_text.should eq "Some of this text is hidden!"
+      expect(driver.find_xpath("//*[@id='hidden-text']").first.all_text).to eq "Some of this text is hidden!"
     end
 
     it "returns the current URL" do
       visit "/hello/world?success=true"
-      driver.current_url.should eq driver_url(driver, "/hello/world?success=true")
+      expect(driver.current_url).to eq driver_url(driver, "/hello/world?success=true")
     end
 
     it "returns the current URL when changed by pushState" do
       driver.execute_script("window.history.pushState({}, '', '/pushed')")
-      driver.current_url.should eq driver_url(driver, "/pushed")
+      expect(driver.current_url).to eq driver_url(driver, "/pushed")
     end
 
     it "returns the current URL when changed by replaceState" do
       driver.execute_script("window.history.replaceState({}, '', '/replaced')")
-      driver.current_url.should eq driver_url(driver, "/replaced")
+      expect(driver.current_url).to eq driver_url(driver, "/replaced")
     end
 
     it "does not double-encode URLs" do
       visit("/hello/world?success=%25true")
-      driver.current_url.should =~ /success=\%25true/
+      expect(driver.current_url).to match(/success=\%25true/)
     end
 
     it "returns the current URL with encoded characters" do
       visit("/hello/world?success[value]=true")
       current_url = Rack::Utils.unescape(driver.current_url)
-      current_url.should include('success[value]=true')
+      expect(current_url).to include('success[value]=true')
     end
 
     it "visits a page with an anchor" do
       visit("/hello#display_none")
-      driver.current_url.should =~ /hello#display_none/
+      expect(driver.current_url).to match(/hello#display_none/)
     end
 
     it "evaluates Javascript and returns a string" do
       result = driver.evaluate_script(%<document.getElementById('greeting').innerText>)
-      result.should eq "hello"
+      expect(result).to eq "hello"
     end
 
     it "evaluates Javascript and returns an array" do
       result = driver.evaluate_script(%<["hello", "world"]>)
-      result.should eq %w(hello world)
+      expect(result).to eq %w(hello world)
     end
 
     it "evaluates Javascript and returns an int" do
       result = driver.evaluate_script(%<123>)
-      result.should eq 123
+      expect(result).to eq 123
     end
 
     it "evaluates Javascript and returns a float" do
       result = driver.evaluate_script(%<1.5>)
-      result.should eq 1.5
+      expect(result).to eq 1.5
     end
 
     it "evaluates Javascript and returns null" do
       result = driver.evaluate_script(%<(function () {})()>)
-      result.should eq nil
+      expect(result).to eq nil
     end
 
     it "evaluates Infinity and returns null" do
       result = driver.evaluate_script(%<Infinity>)
-      result.should eq nil
+      expect(result).to eq nil
     end
 
     it "evaluates Javascript and returns an object" do
       result = driver.evaluate_script(%<({ 'one' : 1 })>)
-      result.should eq 'one' => 1
+      expect(result).to eq 'one' => 1
     end
 
     it "evaluates Javascript and returns true" do
       result = driver.evaluate_script(%<true>)
-      result.should === true
+      expect(result).to be === true
     end
 
     it "evaluates Javascript and returns false" do
       result = driver.evaluate_script(%<false>)
-      result.should === false
+      expect(result).to be === false
     end
 
     it "evaluates Javascript and returns an escaped string" do
       result = driver.evaluate_script(%<'"'>)
-      result.should === "\""
+      expect(result).to be === "\""
     end
 
     it "evaluates Javascript with multiple lines" do
       result = driver.evaluate_script("[1,\n2]")
-      result.should eq [1, 2]
+      expect(result).to eq [1, 2]
     end
 
     it "executes Javascript" do
       driver.execute_script(%<document.getElementById('greeting').innerHTML = 'yo'>)
-      driver.find_xpath("//p[contains(., 'yo')]").should_not be_empty
+      expect(driver.find_xpath("//p[contains(., 'yo')]")).not_to be_empty
     end
 
     it "raises an error for failing Javascript" do
@@ -501,34 +501,34 @@ describe Capybara::Webkit::Driver do
     end
 
     it "doesn't raise an error for Javascript that doesn't return anything" do
-      lambda { driver.execute_script(%<(function () { "returns nothing" })()>) }.
-        should_not raise_error
+      expect { driver.execute_script(%<(function () { "returns nothing" })()>) }.
+        not_to raise_error
     end
 
     it "returns a node's tag name" do
-      driver.find_xpath("//p").first.tag_name.should eq "p"
+      expect(driver.find_xpath("//p").first.tag_name).to eq "p"
     end
 
     it "reads disabled property" do
-      driver.find_xpath("//input").first.should be_disabled
+      expect(driver.find_xpath("//input").first).to be_disabled
     end
 
     it "reads checked property" do
-      driver.find_xpath("//input[@id='checktest']").first.should be_checked
+      expect(driver.find_xpath("//input[@id='checktest']").first).to be_checked
     end
 
     it "finds visible elements" do
-      driver.find_xpath("//p").first.should be_visible
-      driver.find_xpath("//*[@id='invisible']").first.should_not be_visible
-      driver.find_xpath("//*[@id='invisible_with_visibility']").first.should_not be_visible
+      expect(driver.find_xpath("//p").first).to be_visible
+      expect(driver.find_xpath("//*[@id='invisible']").first).not_to be_visible
+      expect(driver.find_xpath("//*[@id='invisible_with_visibility']").first).not_to be_visible
     end
 
     it "returns the document title" do
-      driver.title.should eq "Title"
+      expect(driver.title).to eq "Title"
     end
 
     it "finds elements by CSS" do
-      driver.find_css("p").first.visible_text.should eq "hello"
+      expect(driver.find_css("p").first.visible_text).to eq "hello"
     end
   end
 
@@ -548,7 +548,7 @@ describe Capybara::Webkit::Driver do
     before { visit("/") }
 
     it "should handle text for svg elements" do
-      driver.find_xpath("//*[@id='navy_text']").first.visible_text.should eq "In the navy!"
+      expect(driver.find_xpath("//*[@id='navy_text']").first.visible_text).to eq "In the navy!"
     end
   end
 
@@ -577,34 +577,34 @@ describe Capybara::Webkit::Driver do
     it "collects messages logged to the console" do
       url = driver_url(driver, "/")
       message = driver.console_messages.first
-      message.should include :source => url, :message => "hello"
-      [6, 7].should include message[:line_number]
-      driver.console_messages.length.should eq 5
+      expect(message).to include :source => url, :message => "hello"
+      expect([6, 7]).to include message[:line_number]
+      expect(driver.console_messages.length).to eq 5
     end
 
     it "logs errors to the console" do
-      driver.error_messages.length.should eq 1
+      expect(driver.error_messages.length).to eq 1
     end
 
     it "supports multi-line console messages" do
       message = driver.console_messages[2]
-      message[:message].should eq "hello\nnewline"
+      expect(message[:message]).to eq "hello\nnewline"
     end
 
     it "empties the array when reset" do
       driver.reset!
-      driver.console_messages.should be_empty
+      expect(driver.console_messages).to be_empty
     end
 
     it "supports console messages from an unknown source" do
       driver.execute_script("console.log('hello')")
-      driver.console_messages.last[:message].should eq 'hello'
-      driver.console_messages.last[:source].should be_nil
-      driver.console_messages.last[:line_number].should be_nil
+      expect(driver.console_messages.last[:message]).to eq 'hello'
+      expect(driver.console_messages.last[:source]).to be_nil
+      expect(driver.console_messages.last[:line_number]).to be_nil
     end
 
     it "escapes unicode console messages" do
-      driver.console_messages[3][:message].should eq '𝄞'
+      expect(driver.console_messages[3][:message]).to eq '𝄞'
     end
   end
 
@@ -627,12 +627,12 @@ describe Capybara::Webkit::Driver do
       before { visit("/") }
 
       it "should let me read my alert messages" do
-        driver.alert_messages.first.should eq "Alert Text\nGoes Here"
+        expect(driver.alert_messages.first).to eq "Alert Text\nGoes Here"
       end
 
       it "empties the array when reset" do
         driver.reset!
-        driver.alert_messages.should be_empty
+        expect(driver.alert_messages).to be_empty
       end
     end
 
@@ -661,31 +661,31 @@ describe Capybara::Webkit::Driver do
 
       it "should default to accept the confirm" do
         driver.find_xpath("//input").first.click
-        driver.console_messages.first[:message].should eq "hello"
+        expect(driver.console_messages.first[:message]).to eq "hello"
       end
 
       it "can dismiss the confirm" do
         driver.dismiss_js_confirms!
         driver.find_xpath("//input").first.click
-        driver.console_messages.first[:message].should eq "goodbye"
+        expect(driver.console_messages.first[:message]).to eq "goodbye"
       end
 
       it "can accept the confirm explicitly" do
         driver.dismiss_js_confirms!
         driver.accept_js_confirms!
         driver.find_xpath("//input").first.click
-        driver.console_messages.first[:message].should eq "hello"
+        expect(driver.console_messages.first[:message]).to eq "hello"
       end
 
       it "should collect the javascript confirm dialog contents" do
         driver.find_xpath("//input").first.click
-        driver.confirm_messages.first.should eq "Yes?"
+        expect(driver.confirm_messages.first).to eq "Yes?"
       end
 
       it "empties the array when reset" do
         driver.find_xpath("//input").first.click
         driver.reset!
-        driver.confirm_messages.should be_empty
+        expect(driver.confirm_messages).to be_empty
       end
 
       it "resets to the default of accepting confirms" do
@@ -693,12 +693,12 @@ describe Capybara::Webkit::Driver do
         driver.reset!
         visit("/")
         driver.find_xpath("//input").first.click
-        driver.console_messages.first[:message].should eq "hello"
+        expect(driver.console_messages.first[:message]).to eq "hello"
       end
 
       it "supports multi-line confirmation messages" do
         driver.execute_script("confirm('Hello\\nnewline')")
-        driver.confirm_messages.first.should eq "Hello\nnewline"
+        expect(driver.confirm_messages.first).to eq "Hello\nnewline"
       end
 
     end
@@ -729,48 +729,48 @@ describe Capybara::Webkit::Driver do
 
       it "should default to dismiss the prompt" do
         driver.find_xpath("//input").first.click
-        driver.console_messages.first[:message].should eq "goodbye"
+        expect(driver.console_messages.first[:message]).to eq "goodbye"
       end
 
       it "can accept the prompt without providing text" do
         driver.accept_js_prompts!
         driver.find_xpath("//input").first.click
-        driver.console_messages.first[:message].should eq "hello John Smith"
+        expect(driver.console_messages.first[:message]).to eq "hello John Smith"
       end
 
       it "can accept the prompt with input" do
         driver.js_prompt_input = "Capy"
         driver.accept_js_prompts!
         driver.find_xpath("//input").first.click
-        driver.console_messages.first[:message].should eq "hello Capy"
+        expect(driver.console_messages.first[:message]).to eq "hello Capy"
       end
 
       it "can return to dismiss the prompt after accepting prompts" do
         driver.accept_js_prompts!
         driver.dismiss_js_prompts!
         driver.find_xpath("//input").first.click
-        driver.console_messages.first[:message].should eq "goodbye"
+        expect(driver.console_messages.first[:message]).to eq "goodbye"
       end
 
       it "should let me remove the prompt input text" do
         driver.js_prompt_input = "Capy"
         driver.accept_js_prompts!
         driver.find_xpath("//input").first.click
-        driver.console_messages.first[:message].should eq "hello Capy"
+        expect(driver.console_messages.first[:message]).to eq "hello Capy"
         driver.js_prompt_input = nil
         driver.find_xpath("//input").first.click
-        driver.console_messages.last[:message].should eq "hello John Smith"
+        expect(driver.console_messages.last[:message]).to eq "hello John Smith"
       end
 
       it "should collect the javascript prompt dialog contents" do
         driver.find_xpath("//input").first.click
-        driver.prompt_messages.first.should eq "Your name?"
+        expect(driver.prompt_messages.first).to eq "Your name?"
       end
 
       it "empties the array when reset" do
         driver.find_xpath("//input").first.click
         driver.reset!
-        driver.prompt_messages.should be_empty
+        expect(driver.prompt_messages).to be_empty
       end
 
       it "returns the prompt action to dismiss on reset" do
@@ -778,12 +778,12 @@ describe Capybara::Webkit::Driver do
         driver.reset!
         visit("/")
         driver.find_xpath("//input").first.click
-        driver.console_messages.first[:message].should eq "goodbye"
+        expect(driver.console_messages.first[:message]).to eq "goodbye"
       end
 
       it "supports multi-line prompt messages" do
         driver.execute_script("prompt('Hello\\nnewline')")
-        driver.prompt_messages.first.should eq "Hello\nnewline"
+        expect(driver.prompt_messages.first).to eq "Hello\nnewline"
       end
 
     end
@@ -831,57 +831,57 @@ describe Capybara::Webkit::Driver do
     before { visit("/") }
 
     it "returns a textarea's value" do
-      driver.find_xpath("//textarea").first.value.should eq "what a wonderful area for text"
+      expect(driver.find_xpath("//textarea").first.value).to eq "what a wonderful area for text"
     end
 
     it "returns a text input's value" do
-      driver.find_xpath("//input").first.value.should eq "bar"
+      expect(driver.find_xpath("//input").first.value).to eq "bar"
     end
 
     it "returns a select's value" do
-      driver.find_xpath("//select").first.value.should eq "Capybara"
+      expect(driver.find_xpath("//select").first.value).to eq "Capybara"
     end
 
     it "sets an input's value" do
       input = driver.find_xpath("//input").first
       input.set("newvalue")
-      input.value.should eq "newvalue"
+      expect(input.value).to eq "newvalue"
     end
 
     it "sets an input's value greater than the max length" do
       input = driver.find_xpath("//input[@name='maxlength_foo']").first
       input.set("allegories (poems)")
-      input.value.should eq "allegories"
+      expect(input.value).to eq "allegories"
     end
 
     it "sets an input's value equal to the max length" do
       input = driver.find_xpath("//input[@name='maxlength_foo']").first
       input.set("allegories")
-      input.value.should eq "allegories"
+      expect(input.value).to eq "allegories"
     end
 
     it "sets an input's value less than the max length" do
       input = driver.find_xpath("//input[@name='maxlength_foo']").first
       input.set("poems")
-      input.value.should eq "poems"
+      expect(input.value).to eq "poems"
     end
 
     it "sets an input's nil value" do
       input = driver.find_xpath("//input").first
       input.set(nil)
-      input.value.should eq ""
+      expect(input.value).to eq ""
     end
 
     it "sets a select's value" do
       select = driver.find_xpath("//select").first
       select.set("Monkey")
-      select.value.should eq "Monkey"
+      expect(select.value).to eq "Monkey"
     end
 
     it "sets a textarea's value" do
       textarea = driver.find_xpath("//textarea").first
       textarea.set("newvalue")
-      textarea.value.should eq "newvalue"
+      expect(textarea.value).to eq "newvalue"
     end
 
     let(:monkey_option)   { driver.find_xpath("//option[@id='select-option-monkey']").first }
@@ -897,52 +897,52 @@ describe Capybara::Webkit::Driver do
 
     context "a select element's selection has been changed" do
       before do
-        animal_select.value.should eq "Capybara"
+        expect(animal_select.value).to eq "Capybara"
         monkey_option.select_option
       end
 
       it "returns the new selection" do
-        animal_select.value.should eq "Monkey"
+        expect(animal_select.value).to eq "Monkey"
       end
 
       it "does not modify the selected attribute of a new selection" do
-        monkey_option['selected'].should be_nil
+        expect(monkey_option['selected']).to be_nil
       end
 
       it "returns the old value when a reset button is clicked" do
         reset_button.click
 
-        animal_select.value.should eq "Capybara"
+        expect(animal_select.value).to eq "Capybara"
       end
     end
 
     context "a multi-select element's option has been unselected" do
       before do
-        toppings_select.value.should include("Apple", "Banana", "Cherry")
+        expect(toppings_select.value).to include("Apple", "Banana", "Cherry")
 
         apple_option.unselect_option
       end
 
       it "does not return the deselected option" do
-        toppings_select.value.should_not include("Apple")
+        expect(toppings_select.value).not_to include("Apple")
       end
 
       it "returns the deselected option when a reset button is clicked" do
         reset_button.click
 
-        toppings_select.value.should include("Apple", "Banana", "Cherry")
+        expect(toppings_select.value).to include("Apple", "Banana", "Cherry")
       end
     end
 
     context "a multi-select (with empty multiple attribute) element's option has been unselected" do
       before do
-        guitars_select.value.should include("Fender", "Gibson")
+        expect(guitars_select.value).to include("Fender", "Gibson")
 
         fender_option.unselect_option
       end
 
       it "does not return the deselected option" do
-        guitars_select.value.should_not include("Fender")
+        expect(guitars_select.value).not_to include("Fender")
       end
     end
 
@@ -951,73 +951,73 @@ describe Capybara::Webkit::Driver do
       banana_option.unselect_option
       cherry_option.unselect_option
 
-      toppings_select.value.should eq []
+      expect(toppings_select.value).to eq []
 
       apple_option.select_option
       banana_option.select_option
       cherry_option.select_option
 
-      toppings_select.value.should include("Apple", "Banana", "Cherry")
+      expect(toppings_select.value).to include("Apple", "Banana", "Cherry")
     end
 
     let(:checked_box) { driver.find_xpath("//input[@name='checkedbox']").first }
     let(:unchecked_box) { driver.find_xpath("//input[@name='uncheckedbox']").first }
 
     it "knows a checked box is checked" do
-      checked_box['checked'].should be_true
+      expect(checked_box['checked']).to be_true
     end
 
     it "knows a checked box is checked using checked?" do
-      checked_box.should be_checked
+      expect(checked_box).to be_checked
     end
 
     it "knows an unchecked box is unchecked" do
-      unchecked_box['checked'].should_not be_true
+      expect(unchecked_box['checked']).not_to be_true
     end
 
     it "knows an unchecked box is unchecked using checked?" do
-      unchecked_box.should_not be_checked
+      expect(unchecked_box).not_to be_checked
     end
 
     it "checks an unchecked box" do
       unchecked_box.set(true)
-      unchecked_box.should be_checked
+      expect(unchecked_box).to be_checked
     end
 
     it "unchecks a checked box" do
       checked_box.set(false)
-      checked_box.should_not be_checked
+      expect(checked_box).not_to be_checked
     end
 
     it "leaves a checked box checked" do
       checked_box.set(true)
-      checked_box.should be_checked
+      expect(checked_box).to be_checked
     end
 
     it "leaves an unchecked box unchecked" do
       unchecked_box.set(false)
-      unchecked_box.should_not be_checked
+      expect(unchecked_box).not_to be_checked
     end
 
     let(:enabled_input)  { driver.find_xpath("//input[@name='foo']").first }
     let(:disabled_input) { driver.find_xpath("//input[@id='disabled_input']").first }
 
     it "knows a disabled input is disabled" do
-      disabled_input['disabled'].should be_true
+      expect(disabled_input['disabled']).to be_true
     end
 
     it "knows a not disabled input is not disabled" do
-      enabled_input['disabled'].should_not be_true
+      expect(enabled_input['disabled']).not_to be_true
     end
 
     it "does not modify a readonly input" do
       readonly_input = driver.find_css("#readonly_input").first
       readonly_input.set('enabled')
-      readonly_input.value.should eq 'readonly'
+      expect(readonly_input.value).to eq 'readonly'
     end
 
     it "should see enabled options in disabled select as disabled" do
-      driver.find_css("#select-option-disabled").first.should be_disabled
+      expect(driver.find_css("#select-option-disabled").first).to be_disabled
     end
   end
 
@@ -1056,18 +1056,18 @@ describe Capybara::Webkit::Driver do
 
     it "triggers mouse events" do
       watch.click
-      fired_events.should eq %w(mousedown mouseup click)
+      expect(fired_events).to eq %w(mousedown mouseup click)
     end
 
     it "triggers double click" do
       # check event order at http://www.quirksmode.org/dom/events/click.html
       watch.double_click
-      fired_events.should eq %w(mousedown mouseup click mousedown mouseup click dblclick)
+      expect(fired_events).to eq %w(mousedown mouseup click mousedown mouseup click dblclick)
     end
 
     it "triggers right click" do
       watch.right_click
-      fired_events.should eq %w(mousedown contextmenu mouseup)
+      expect(fired_events).to eq %w(mousedown contextmenu mouseup)
     end
   end
 
@@ -1128,23 +1128,23 @@ describe Capybara::Webkit::Driver do
     %w(email number password search tel text url).each do | field_type |
       it "triggers text input events on inputs of type #{field_type}" do
         driver.find_xpath("//input[@type='#{field_type}']").first.set(newtext)
-        driver.find_xpath("//li").map(&:visible_text).should eq keyevents
+        expect(driver.find_xpath("//li").map(&:visible_text)).to eq keyevents
       end
     end
 
     it "triggers textarea input events" do
       driver.find_xpath("//textarea").first.set(newtext)
-      driver.find_xpath("//li").map(&:visible_text).should eq keyevents
+      expect(driver.find_xpath("//li").map(&:visible_text)).to eq keyevents
     end
 
     it "triggers radio input events" do
       driver.find_xpath("//input[@type='radio']").first.set(true)
-      driver.find_xpath("//li").map(&:visible_text).should eq %w(mousedown focus mouseup change click)
+      expect(driver.find_xpath("//li").map(&:visible_text)).to eq %w(mousedown focus mouseup change click)
     end
 
     it "triggers checkbox events" do
       driver.find_xpath("//input[@type='checkbox']").first.set(true)
-      driver.find_xpath("//li").map(&:visible_text).should eq %w(mousedown focus mouseup change click)
+      expect(driver.find_xpath("//li").map(&:visible_text)).to eq %w(mousedown focus mouseup change click)
     end
   end
 
@@ -1200,9 +1200,9 @@ describe Capybara::Webkit::Driver do
     before { visit("/") }
 
     it "hovers an element" do
-      driver.find_css("#hover").first.visible_text.should_not =~ /Text that only shows on hover/
+      expect(driver.find_css("#hover").first.visible_text).not_to match(/Text that only shows on hover/)
       driver.find_css("#hover span").first.hover
-      driver.find_css("#hover").first.visible_text.should =~ /Text that only shows on hover/
+      expect(driver.find_css("#hover").first.visible_text).to match(/Text that only shows on hover/)
     end
 
     it "hovers an element off the screen" do
@@ -1212,9 +1212,9 @@ describe Capybara::Webkit::Driver do
         element.style.position = 'absolute';
         element.style.left = '200px';
       JS
-      driver.find_css("#hover").first.visible_text.should_not =~ /Text that only shows on hover/
+      expect(driver.find_css("#hover").first.visible_text).not_to match(/Text that only shows on hover/)
       driver.find_css("#hover span").first.hover
-      driver.find_css("#hover").first.visible_text.should =~ /Text that only shows on hover/
+      expect(driver.find_css("#hover").first.visible_text).to match(/Text that only shows on hover/)
     end
 
     it "clicks an element" do
@@ -1224,21 +1224,21 @@ describe Capybara::Webkit::Driver do
 
     it "fires a mouse event" do
       driver.find_xpath("//*[@id='mouseup']").first.trigger("mouseup")
-      driver.find_xpath("//*[@class='triggered']").should_not be_empty
+      expect(driver.find_xpath("//*[@class='triggered']")).not_to be_empty
     end
 
     it "fires a non-mouse event" do
       driver.find_xpath("//*[@id='change']").first.trigger("change")
-      driver.find_xpath("//*[@class='triggered']").should_not be_empty
+      expect(driver.find_xpath("//*[@class='triggered']")).not_to be_empty
     end
 
     it "fires a change on select" do
       select = driver.find_xpath("//select").first
-      select.value.should eq "1"
+      expect(select.value).to eq "1"
       option = driver.find_xpath("//option[@id='option-2']").first
       option.select_option
-      select.value.should eq "2"
-      driver.find_xpath("//select[@class='triggered']").should_not be_empty
+      expect(select.value).to eq "2"
+      expect(driver.find_xpath("//select[@class='triggered']")).not_to be_empty
     end
 
     it "fires drag events" do
@@ -1247,7 +1247,7 @@ describe Capybara::Webkit::Driver do
 
       draggable.drag_to(container)
 
-      driver.find_xpath("//*[@class='triggered']").size.should eq 1
+      expect(driver.find_xpath("//*[@class='triggered']").size).to eq 1
     end
   end
 
@@ -1267,12 +1267,12 @@ describe Capybara::Webkit::Driver do
 
     it "evaluates nested xpath expressions" do
       parent = driver.find_xpath("//*[@id='parent']").first
-      parent.find_xpath("./*[@class='find']").map(&:visible_text).should eq %w(Expected)
+      expect(parent.find_xpath("./*[@class='find']").map(&:visible_text)).to eq %w(Expected)
     end
 
     it "finds elements by CSS" do
       parent = driver.find_css("#parent").first
-      parent.find_css(".find").first.visible_text.should eq "Expected"
+      expect(parent.find_css(".find").first.visible_text).to eq "Expected"
     end
   end
 
@@ -1292,7 +1292,7 @@ describe Capybara::Webkit::Driver do
       end
       visit("/", driver)
       driver.find_xpath("//a").first.click
-      result.should eq "finished"
+      expect(result).to eq "finished"
     end
   end
 
@@ -1354,7 +1354,7 @@ describe Capybara::Webkit::Driver do
       driver.find_xpath("//input").first.click
       expect { driver.find_xpath("//p") }.to raise_error(Capybara::Webkit::InvalidResponseError)
       visit("/")
-      driver.find_xpath("//p").first.visible_text.should eq "hello"
+      expect(driver.find_xpath("//p").first.visible_text).to eq "hello"
     end
   end
 
@@ -1380,7 +1380,7 @@ describe Capybara::Webkit::Driver do
     before { visit("/") }
 
     it "doesn't crash from alerts" do
-      driver.find_xpath("//p").first.visible_text.should eq "success"
+      expect(driver.find_xpath("//p").first.visible_text).to eq "success"
     end
   end
 
@@ -1410,31 +1410,31 @@ describe Capybara::Webkit::Driver do
     end
 
     it "can set user_agent" do
-      driver.find_xpath('id("user-agent")').first.visible_text.should eq 'capybara-webkit/custom-user-agent'
-      driver.evaluate_script('navigator.userAgent').should eq 'capybara-webkit/custom-user-agent'
+      expect(driver.find_xpath('id("user-agent")').first.visible_text).to eq 'capybara-webkit/custom-user-agent'
+      expect(driver.evaluate_script('navigator.userAgent')).to eq 'capybara-webkit/custom-user-agent'
     end
 
     it "keep user_agent in next page" do
       driver.find_xpath("//a").first.click
-      driver.find_xpath('id("user-agent")').first.visible_text.should eq 'capybara-webkit/custom-user-agent'
-      driver.evaluate_script('navigator.userAgent').should eq 'capybara-webkit/custom-user-agent'
+      expect(driver.find_xpath('id("user-agent")').first.visible_text).to eq 'capybara-webkit/custom-user-agent'
+      expect(driver.evaluate_script('navigator.userAgent')).to eq 'capybara-webkit/custom-user-agent'
     end
 
     it "can set custom header" do
-      driver.find_xpath('id("x-capybara-webkit-header")').first.visible_text.should eq 'x-capybara-webkit-header'
+      expect(driver.find_xpath('id("x-capybara-webkit-header")').first.visible_text).to eq 'x-capybara-webkit-header'
     end
 
     it "can set Accept header" do
-      driver.find_xpath('id("accept")').first.visible_text.should eq 'text/html'
+      expect(driver.find_xpath('id("accept")').first.visible_text).to eq 'text/html'
     end
 
     it "can reset all custom header" do
       driver.reset!
       visit('/')
-      driver.find_xpath('id("user-agent")').first.visible_text.should_not eq 'capybara-webkit/custom-user-agent'
-      driver.evaluate_script('navigator.userAgent').should_not eq 'capybara-webkit/custom-user-agent'
-      driver.find_xpath('id("x-capybara-webkit-header")').first.visible_text.should be_empty
-      driver.find_xpath('id("accept")').first.visible_text.should_not eq 'text/html'
+      expect(driver.find_xpath('id("user-agent")').first.visible_text).not_to eq 'capybara-webkit/custom-user-agent'
+      expect(driver.evaluate_script('navigator.userAgent')).not_to eq 'capybara-webkit/custom-user-agent'
+      expect(driver.find_xpath('id("x-capybara-webkit-header")').first.visible_text).to be_empty
+      expect(driver.find_xpath('id("accept")').first.visible_text).not_to eq 'text/html'
     end
   end
 
@@ -1459,15 +1459,15 @@ describe Capybara::Webkit::Driver do
     end
 
     def make_the_server_come_back
-      driver.browser.instance_variable_get(:@connection).unstub(:gets)
-      driver.browser.instance_variable_get(:@connection).unstub(:puts)
-      driver.browser.instance_variable_get(:@connection).unstub(:print)
+      allow(driver.browser.instance_variable_get(:@connection)).to receive(:gets).and_call_original
+      allow(driver.browser.instance_variable_get(:@connection)).to receive(:puts).and_call_original
+      allow(driver.browser.instance_variable_get(:@connection)).to receive(:print).and_call_original
     end
 
     def make_the_server_go_away
-      driver.browser.instance_variable_get(:@connection).stub(:gets).and_return(nil)
-      driver.browser.instance_variable_get(:@connection).stub(:puts)
-      driver.browser.instance_variable_get(:@connection).stub(:print)
+      allow(driver.browser.instance_variable_get(:@connection)).to receive(:gets).and_return(nil)
+      allow(driver.browser.instance_variable_get(:@connection)).to receive(:puts)
+      allow(driver.browser.instance_variable_get(:@connection)).to receive(:print)
     end
   end
 
@@ -1499,15 +1499,15 @@ describe Capybara::Webkit::Driver do
     end
 
     it "ignores custom fonts" do
-      font_family.should eq "Arial"
+      expect(font_family).to eq "Arial"
     end
 
     it "ignores custom fonts before an element" do
-      font_family.should eq "Arial"
+      expect(font_family).to eq "Arial"
     end
 
     it "ignores custom fonts after an element" do
-      font_family.should eq "Arial"
+      expect(font_family).to eq "Arial"
     end
   end
 
@@ -1532,36 +1532,36 @@ describe Capybara::Webkit::Driver do
     end
 
     it "remembers the cookie on second visit" do
-      echoed_cookie.should eq ""
+      expect(echoed_cookie).to eq ""
       visit "/"
-      echoed_cookie.should eq "abc"
+      expect(echoed_cookie).to eq "abc"
     end
 
     it "uses a custom cookie" do
       driver.browser.set_cookie 'cookie=abc; domain=127.0.0.1; path=/'
       visit "/"
-      echoed_cookie.should eq "abc"
+      expect(echoed_cookie).to eq "abc"
     end
 
     it "clears cookies" do
       driver.browser.clear_cookies
       visit "/"
-      echoed_cookie.should eq ""
+      expect(echoed_cookie).to eq ""
     end
 
     it "allows enumeration of cookies" do
       cookies = driver.browser.get_cookies
 
-      cookies.size.should eq 1
+      expect(cookies.size).to eq 1
 
       cookie = Hash[cookies[0].split(/\s*;\s*/).map { |x| x.split("=", 2) }]
-      cookie["cookie"].should eq "abc"
-      cookie["domain"].should include "127.0.0.1"
-      cookie["path"].should eq "/"
+      expect(cookie["cookie"]).to eq "abc"
+      expect(cookie["domain"]).to include "127.0.0.1"
+      expect(cookie["path"]).to eq "/"
     end
 
     it "allows reading access to cookies using a nice syntax" do
-      driver.cookies["cookie"].should eq "abc"
+      expect(driver.cookies["cookie"]).to eq "abc"
     end
   end
 
@@ -1590,7 +1590,7 @@ describe Capybara::Webkit::Driver do
     it "allows removed nodes when reloading is disabled" do
       node = driver.find_xpath("//p[@id='removeMe']").first
       driver.evaluate_script("document.getElementById('parent').innerHTML = 'Magic'")
-      node.visible_text.should eq 'Hello'
+      expect(node.visible_text).to eq 'Hello'
     end
   end
 
@@ -1651,8 +1651,8 @@ describe Capybara::Webkit::Driver do
 
       cases.each do |xpath, path|
         nodes = driver.find_xpath(xpath)
-        nodes.size.should eq 1
-        nodes[0].path.should eq path
+        expect(nodes.size).to eq 1
+        expect(nodes[0].path).to eq path
       end
     end
   end
@@ -1676,7 +1676,7 @@ describe Capybara::Webkit::Driver do
     before { visit("/") }
 
     it "handles overflow hidden" do
-      driver.find_xpath("//div[@id='overflow']").first.visible_text.should eq "Overflow"
+      expect(driver.find_xpath("//div[@id='overflow']").first.visible_text).to eq "Overflow"
     end
   end
 
@@ -1702,7 +1702,7 @@ describe Capybara::Webkit::Driver do
     it "loads a page without error" do
       10.times do
         visit("/redirect")
-        driver.find_xpath("//p").first.visible_text.should eq "finished"
+        expect(driver.find_xpath("//p").first.visible_text).to eq "finished"
       end
     end
   end
@@ -1731,17 +1731,17 @@ describe Capybara::Webkit::Driver do
     before { visit("/") }
 
     it "displays the message on subsequent page loads" do
-      driver.find_xpath("//span[contains(.,'localStorage is enabled')]").should be_empty
+      expect(driver.find_xpath("//span[contains(.,'localStorage is enabled')]")).to be_empty
       visit "/"
-      driver.find_xpath("//span[contains(.,'localStorage is enabled')]").should_not be_empty
+      expect(driver.find_xpath("//span[contains(.,'localStorage is enabled')]")).not_to be_empty
     end
 
     it "clears the message after a driver reset!" do
       visit "/"
-      driver.find_xpath("//span[contains(.,'localStorage is enabled')]").should_not be_empty
+      expect(driver.find_xpath("//span[contains(.,'localStorage is enabled')]")).not_to be_empty
       driver.reset!
       visit "/"
-      driver.find_xpath("//span[contains(.,'localStorage is enabled')]").should be_empty
+      expect(driver.find_xpath("//span[contains(.,'localStorage is enabled')]")).to be_empty
     end
   end
 
@@ -1772,7 +1772,7 @@ describe Capybara::Webkit::Driver do
 
     it "submits a form without clicking" do
       driver.find_xpath("//form")[0].submit
-      driver.html.should include "Congrats"
+      expect(driver.html).to include "Congrats"
     end
   end
 
@@ -1827,59 +1827,59 @@ describe Capybara::Webkit::Driver do
     before { visit("/") }
 
     it "returns the charCode for the keypressed" do
-      charCode_for("a").should eq "97"
-      charCode_for("A").should eq "65"
-      charCode_for("\r").should eq "13"
-      charCode_for(",").should eq "44"
-      charCode_for("<").should eq "60"
-      charCode_for("0").should eq "48"
+      expect(charCode_for("a")).to eq "97"
+      expect(charCode_for("A")).to eq "65"
+      expect(charCode_for("\r")).to eq "13"
+      expect(charCode_for(",")).to eq "44"
+      expect(charCode_for("<")).to eq "60"
+      expect(charCode_for("0")).to eq "48"
     end
 
     it "returns the keyCode for the keypressed" do
-      keyCode_for("a").should eq "97"
-      keyCode_for("A").should eq "65"
-      keyCode_for("\r").should eq "13"
-      keyCode_for(",").should eq "44"
-      keyCode_for("<").should eq "60"
-      keyCode_for("0").should eq "48"
+      expect(keyCode_for("a")).to eq "97"
+      expect(keyCode_for("A")).to eq "65"
+      expect(keyCode_for("\r")).to eq "13"
+      expect(keyCode_for(",")).to eq "44"
+      expect(keyCode_for("<")).to eq "60"
+      expect(keyCode_for("0")).to eq "48"
     end
 
     it "returns the which for the keypressed" do
-      which_for("a").should eq "97"
-      which_for("A").should eq "65"
-      which_for("\r").should eq "13"
-      which_for(",").should eq "44"
-      which_for("<").should eq "60"
-      which_for("0").should eq "48"
+      expect(which_for("a")).to eq "97"
+      expect(which_for("A")).to eq "65"
+      expect(which_for("\r")).to eq "13"
+      expect(which_for(",")).to eq "44"
+      expect(which_for("<")).to eq "60"
+      expect(which_for("0")).to eq "48"
     end
   end
 
   shared_examples "a keyupdown app" do
     it "returns a 0 charCode for the event" do
-      charCode_for("a").should eq "0"
-      charCode_for("A").should eq "0"
-      charCode_for("\b").should eq "0"
-      charCode_for(",").should eq "0"
-      charCode_for("<").should eq "0"
-      charCode_for("0").should eq "0"
+      expect(charCode_for("a")).to eq "0"
+      expect(charCode_for("A")).to eq "0"
+      expect(charCode_for("\b")).to eq "0"
+      expect(charCode_for(",")).to eq "0"
+      expect(charCode_for("<")).to eq "0"
+      expect(charCode_for("0")).to eq "0"
     end
 
     it "returns the keyCode for the event" do
-      keyCode_for("a").should eq "65"
-      keyCode_for("A").should eq "65"
-      keyCode_for("\b").should eq "8"
-      keyCode_for(",").should eq "188"
-      keyCode_for("<").should eq "188"
-      keyCode_for("0").should eq "48"
+      expect(keyCode_for("a")).to eq "65"
+      expect(keyCode_for("A")).to eq "65"
+      expect(keyCode_for("\b")).to eq "8"
+      expect(keyCode_for(",")).to eq "188"
+      expect(keyCode_for("<")).to eq "188"
+      expect(keyCode_for("0")).to eq "48"
     end
 
     it "returns the which for the event" do
-      which_for("a").should eq "65"
-      which_for("A").should eq "65"
-      which_for("\b").should eq "8"
-      which_for(",").should eq "188"
-      which_for("<").should eq "188"
-      which_for("0").should eq "48"
+      expect(which_for("a")).to eq "65"
+      expect(which_for("A")).to eq "65"
+      expect(which_for("\b")).to eq "8"
+      expect(which_for(",")).to eq "188"
+      expect(which_for("<")).to eq "188"
+      expect(which_for("0")).to eq "48"
     end
   end
 
@@ -1921,14 +1921,14 @@ describe Capybara::Webkit::Driver do
     it "has the expected text in the new window" do
       visit("/new_window")
       driver.within_window(driver.window_handles.last) do
-        driver.find_xpath("//p").first.visible_text.should eq "finished"
+        expect(driver.find_xpath("//p").first.visible_text).to eq "finished"
       end
     end
 
     it "waits for the new window to load" do
       visit("/new_window?sleep=1")
       driver.within_window(driver.window_handles.last) do
-        driver.find_xpath("//p").first.visible_text.should eq "finished"
+        expect(driver.find_xpath("//p").first.visible_text).to eq "finished"
       end
     end
 
@@ -1936,34 +1936,34 @@ describe Capybara::Webkit::Driver do
       visit("/new_window?sleep=2")
       driver.execute_script("setTimeout(function() { window.location = 'about:blank' }, 1000)")
       driver.within_window(driver.window_handles.last) do
-        driver.find_xpath("//p").first.visible_text.should eq "finished"
+        expect(driver.find_xpath("//p").first.visible_text).to eq "finished"
       end
     end
 
     it "switches back to the original window" do
       visit("/new_window")
       driver.within_window(driver.window_handles.last) { }
-      driver.find_xpath("//p").first.visible_text.should eq "bananas"
+      expect(driver.find_xpath("//p").first.visible_text).to eq "bananas"
     end
 
     it "supports finding a window by name" do
       visit("/new_window")
       driver.within_window('myWindow') do
-        driver.find_xpath("//p").first.visible_text.should eq "finished"
+        expect(driver.find_xpath("//p").first.visible_text).to eq "finished"
       end
     end
 
     it "supports finding a window by title" do
       visit("/new_window?sleep=5")
       driver.within_window('My New Window') do
-        driver.find_xpath("//p").first.visible_text.should eq "finished"
+        expect(driver.find_xpath("//p").first.visible_text).to eq "finished"
       end
     end
 
     it "supports finding a window by url" do
       visit("/new_window?test")
       driver.within_window(driver_url(driver, "/?test")) do
-        driver.find_xpath("//p").first.visible_text.should eq "finished"
+        expect(driver.find_xpath("//p").first.visible_text).to eq "finished"
       end
     end
 
@@ -1973,16 +1973,16 @@ describe Capybara::Webkit::Driver do
     end
 
     it "has a number of window handles equal to the number of open windows" do
-      driver.window_handles.size.should eq 1
+      expect(driver.window_handles.size).to eq 1
       visit("/new_window")
-      driver.window_handles.size.should eq 2
+      expect(driver.window_handles.size).to eq 2
     end
 
     it "closes new windows on reset" do
       visit("/new_window")
       last_handle = driver.window_handles.last
       driver.reset!
-      driver.window_handles.should_not include(last_handle)
+      expect(driver.window_handles).not_to include(last_handle)
     end
   end
 
@@ -2005,7 +2005,7 @@ describe Capybara::Webkit::Driver do
     end
 
     visit("/new_window", driver)
-    driver.cookies['session_id'].should eq session_id
+    expect(driver.cookies['session_id']).to eq session_id
   end
 
   context "timers app" do
@@ -2080,20 +2080,20 @@ describe Capybara::Webkit::Driver do
     it "can authenticate a request" do
       driver.browser.authenticate('user', 'password')
       visit("/")
-      driver.html.should include("Basic "+Base64.encode64("user:password").strip)
+      expect(driver.html).to include("Basic "+Base64.encode64("user:password").strip)
     end
 
     it "returns 401 for incorrectly authenticated request" do
       driver.browser.authenticate('user1', 'password1')
       driver.browser.timeout = 2
-      lambda { visit("/") }.should_not raise_error
-      driver.status_code.should eq 401
+      expect { visit("/") }.not_to raise_error
+      expect(driver.status_code).to eq 401
     end
 
     it "returns 401 for unauthenticated request" do
       driver.browser.timeout = 2
-      lambda { visit("/") }.should_not raise_error
-      driver.status_code.should eq 401
+      expect { visit("/") }.not_to raise_error
+      expect(driver.status_code).to eq 401
     end
   end
 
@@ -2140,33 +2140,33 @@ describe Capybara::Webkit::Driver do
     it "should not fetch urls blocked by host" do
       visit("/")
       driver.within_frame('frame1') do
-        driver.find_xpath("//body").first.visible_text.should be_empty
+        expect(driver.find_xpath("//body").first.visible_text).to be_empty
       end
     end
 
     it "should not fetch urls blocked by path" do
       visit('/')
       driver.within_frame('frame2') do
-        driver.find_xpath("//body").first.visible_text.should be_empty
+        expect(driver.find_xpath("//body").first.visible_text).to be_empty
       end
     end
 
     it "should not fetch blocked scripts" do
       visit("/")
-      driver.html.should_not include("Script Run")
+      expect(driver.html).not_to include("Script Run")
     end
 
     it "should fetch unblocked urls" do
       visit('/')
       driver.within_frame('frame3') do
-        driver.find_xpath("//p").first.visible_text.should eq "Inner"
+        expect(driver.find_xpath("//p").first.visible_text).to eq "Inner"
       end
     end
 
     it "returns a status code for blocked urls" do
       visit("/")
       driver.within_frame('frame1') do
-        driver.status_code.should eq 200
+        expect(driver.status_code).to eq 200
       end
     end
   end
@@ -2198,48 +2198,48 @@ describe Capybara::Webkit::Driver do
 
     it "should not raise a timeout error when zero" do
       driver.browser.timeout = 0
-      lambda { visit("/") }.should_not raise_error
+      expect { visit("/") }.not_to raise_error
     end
 
     it "should raise a timeout error" do
       driver.browser.timeout = 1
-      lambda { visit("/") }.should raise_error(Timeout::Error, "Request timed out after 1 second(s)")
+      expect { visit("/") }.to raise_error(Timeout::Error, "Request timed out after 1 second(s)")
     end
 
     it "should not raise an error when the timeout is high enough" do
       driver.browser.timeout = 10
-      lambda { visit("/") }.should_not raise_error
+      expect { visit("/") }.not_to raise_error
     end
 
     it "should set the timeout for each request" do
       driver.browser.timeout = 10
-      lambda { visit("/") }.should_not raise_error
+      expect { visit("/") }.not_to raise_error
       driver.browser.timeout = 1
-      lambda { visit("/") }.should raise_error(Timeout::Error)
+      expect { visit("/") }.to raise_error(Timeout::Error)
     end
 
     it "should set the timeout for each request" do
       driver.browser.timeout = 1
-      lambda { visit("/") }.should raise_error(Timeout::Error)
+      expect { visit("/") }.to raise_error(Timeout::Error)
       driver.reset!
       driver.browser.timeout = 10
-      lambda { visit("/") }.should_not raise_error
+      expect { visit("/") }.not_to raise_error
     end
 
     it "should raise a timeout on a slow form" do
       driver.browser.timeout = 3
       visit("/")
-      driver.status_code.should eq 200
+      expect(driver.status_code).to eq 200
       driver.browser.timeout = 1
       driver.find_xpath("//input").first.click
-      lambda { driver.status_code }.should raise_error(Timeout::Error)
+      expect { driver.status_code }.to raise_error(Timeout::Error)
     end
 
     it "get timeout" do
       driver.browser.timeout = 10
-      driver.browser.timeout.should eq 10
+      expect(driver.browser.timeout).to eq 10
       driver.browser.timeout = 3
-      driver.browser.timeout.should eq 3
+      expect(driver.browser.timeout).to eq 3
     end
   end
 
@@ -2247,14 +2247,14 @@ describe Capybara::Webkit::Driver do
     it "logs nothing before turning on the logger" do
       visit("/")
       @write.close
-      log.should_not include logging_message
+      expect(log).not_to include logging_message
     end
 
     it "logs its commands after turning on the logger" do
       driver.enable_logging
       visit("/")
       @write.close
-      log.should include logging_message
+      expect(log).to include logging_message
     end
 
     before do
@@ -2308,7 +2308,7 @@ describe Capybara::Webkit::Driver do
     it 'should not hang the server' do
       visit('/')
       driver.find_xpath('//input').first.click
-      driver.console_messages.first[:message].should eq "hello"
+      expect(driver.console_messages.first[:message]).to eq "hello"
     end
   end
 
@@ -2327,7 +2327,7 @@ describe Capybara::Webkit::Driver do
     it 'returns an xpath for the current node' do
       visit('/')
       path = driver.find_xpath('//span').first.path
-      driver.find_xpath(path).first.text.should eq 'hello'
+      expect(driver.find_xpath(path).first.text).to eq 'hello'
     end
   end
 
@@ -2378,11 +2378,11 @@ describe Capybara::Webkit::Driver do
 
     it "includes Capybara, capybara-webkit, Qt, and WebKit versions" do
       result = driver.version
-      result.should include("Capybara: #{Capybara::VERSION}")
-      result.should include("capybara-webkit: #{Capybara::Driver::Webkit::VERSION}")
-      result.should =~ /Qt: \d+\.\d+\.\d+/
-      result.should =~ /WebKit: \d+\.\d+/
-      result.should =~ /QtWebKit: \d+\.\d+/
+      expect(result).to include("Capybara: #{Capybara::VERSION}")
+      expect(result).to include("capybara-webkit: #{Capybara::Driver::Webkit::VERSION}")
+      expect(result).to match(/Qt: \d+\.\d+\.\d+/)
+      expect(result).to match(/WebKit: \d+\.\d+/)
+      expect(result).to match(/QtWebKit: \d+\.\d+/)
     end
   end
 

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -7,5 +7,8 @@ describe Capybara::Webkit::JsonError do
 
   it { should be_an_instance_of Capybara::Webkit::ClickFailed }
 
-  its(:message) { should == 'Error clicking this element' }
+  describe '#message' do
+    subject { super().message }
+    it { should == 'Error clicking this element' }
+  end
 end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -51,7 +51,7 @@ describe Capybara::Session do
     it "waits for a request to load" do
       subject.visit("/")
       subject.find_button("Submit").click
-      subject.should have_content("Goodbye");
+      expect(subject).to have_content("Goodbye");
     end
   end
 
@@ -77,12 +77,12 @@ describe Capybara::Session do
     end
 
     it "inspects nodes" do
-      subject.all(:xpath, "//strong").first.inspect.should include("strong")
+      expect(subject.all(:xpath, "//strong").first.inspect).to include("strong")
     end
 
     it "can read utf8 string" do
       utf8str = subject.all(:xpath, "//span").first.text
-      utf8str.should eq('UTF8文字列')
+      expect(utf8str).to eq('UTF8文字列')
     end
 
     it "can click utf8 string" do
@@ -92,7 +92,7 @@ describe Capybara::Session do
     it "raises an ElementNotFound error when the selector scope is no longer valid" do
       subject.within('//body') do
         subject.click_link 'Link'
-        lambda { subject.find('//strong') }.should raise_error(Capybara::ElementNotFound)
+        expect { subject.find('//strong') }.to raise_error(Capybara::ElementNotFound)
       end
     end
   end
@@ -120,26 +120,26 @@ describe Capybara::Session do
 
     it "should get status code" do
       subject.visit '/'
-      subject.status_code.should eq 200
+      expect(subject.status_code).to eq 200
     end
 
     it "should reset status code" do
       subject.visit '/'
-      subject.status_code.should eq 200
+      expect(subject.status_code).to eq 200
       subject.reset!
-      subject.status_code.should eq 0
+      expect(subject.status_code).to eq 0
     end
 
     it "should get response headers" do
       subject.visit '/'
-      subject.response_headers['X-Capybara'].should eq 'WebKit'
+      expect(subject.response_headers['X-Capybara']).to eq 'WebKit'
     end
 
     it "should reset response headers" do
       subject.visit '/'
-      subject.response_headers['X-Capybara'].should eq 'WebKit'
+      expect(subject.response_headers['X-Capybara']).to eq 'WebKit'
       subject.reset!
-      subject.response_headers['X-Capybara'].should eq nil
+      expect(subject.response_headers['X-Capybara']).to eq nil
     end
   end
 
@@ -189,7 +189,7 @@ describe Capybara::Session do
       subject.visit("/")
       subject.click_link('Click Me!')
       Capybara.using_wait_time(5) do
-        subject.should have_content("finished")
+        expect(subject).to have_content("finished")
       end
     end
   end
@@ -236,7 +236,7 @@ describe Capybara::Session do
       subject.fill_in('password', with: 'temp4now')
       subject.click_button('Submit')
       subject.visit('/other')
-      subject.should have_content('admin')
+      expect(subject).to have_content('admin')
     end
   end
 
@@ -300,7 +300,7 @@ describe Capybara::Session do
       subject.within_frame 'a_frame' do
         subject.within_frame 'b_frame' do
           subject.click_button 'B Button'
-          subject.should have_content('Page C')
+          expect(subject).to have_content('Page C')
         end
       end
     end
@@ -320,9 +320,9 @@ describe Capybara::Session do
 
       subject.within_frame('a_frame') do
         subject.within_frame('b_frame') do
-          lambda {
+          expect {
             subject.click_button 'B Button'
-          }.should raise_error(Capybara::Webkit::ClickFailed)
+          }.to raise_error(Capybara::Webkit::ClickFailed)
         end
       end
     end
@@ -380,29 +380,29 @@ describe Capybara::Session do
     it 'clicks in the center of an element' do
       subject.visit('/')
       subject.find(:css, '#one').click
-      subject.find(:css, '#one')['data-click-x'].should eq '199'
-      subject.find(:css, '#one')['data-click-y'].should eq '199'
+      expect(subject.find(:css, '#one')['data-click-x']).to eq '199'
+      expect(subject.find(:css, '#one')['data-click-y']).to eq '199'
     end
 
     it 'clicks in the center of the viewable area of an element' do
       subject.visit('/')
       subject.driver.resize_window(200, 200)
       subject.find(:css, '#one').click
-      subject.find(:css, '#one')['data-click-x'].should eq '149'
-      subject.find(:css, '#one')['data-click-y'].should eq '99'
+      expect(subject.find(:css, '#one')['data-click-x']).to eq '149'
+      expect(subject.find(:css, '#one')['data-click-y']).to eq '99'
     end
 
     it 'does not raise an error when an anchor contains empty nodes' do
       subject.visit('/')
-      lambda { subject.click_link('Some link') }.should_not raise_error
+      expect { subject.click_link('Some link') }.not_to raise_error
     end
 
     it 'scrolls an element into view when clicked' do
       subject.visit('/')
       subject.driver.resize_window(200, 200)
       subject.find(:css, '#two').click
-      subject.find(:css, '#two')['data-click-x'].should_not be_nil
-      subject.find(:css, '#two')['data-click-y'].should_not be_nil
+      expect(subject.find(:css, '#two')['data-click-x']).not_to be_nil
+      expect(subject.find(:css, '#two')['data-click-y']).not_to be_nil
     end
 
     it 'raises an error if an element is obscured when clicked' do
@@ -418,11 +418,11 @@ describe Capybara::Session do
       expect {
         subject.find(:css, '#one').click
       }.to raise_error(Capybara::Webkit::ClickFailed) { |exception|
-        exception.message.should =~ %r{Failed.*\[@id='one'\].*overlapping.*\[@id='two'\].*at position}
+        expect(exception.message).to match(%r{Failed.*\[@id='one'\].*overlapping.*\[@id='two'\].*at position})
         screenshot_pattern = %r{A screenshot of the page at the time of the failure has been written to (.*)}
-        exception.message.should =~ screenshot_pattern
+        expect(exception.message).to match(screenshot_pattern)
         file = exception.message.match(screenshot_pattern)[1]
-        File.exist?(file).should be_true
+        expect(File.exist?(file)).to be_true
       }
     end
 
@@ -439,9 +439,9 @@ describe Capybara::Session do
         document.body.appendChild(div);
       JS
 
-      lambda {
+      expect {
         subject.check('bar')
-      }.should raise_error(Capybara::Webkit::ClickFailed)
+      }.to raise_error(Capybara::Webkit::ClickFailed)
     end
 
     it 'raises an error if an element is not visible when clicked' do
@@ -450,7 +450,7 @@ describe Capybara::Session do
       begin
         subject.visit('/')
         subject.execute_script "document.getElementById('foo').style.display = 'none'"
-        lambda { subject.click_link "Click Me" }.should raise_error(
+        expect { subject.click_link "Click Me" }.to raise_error(
           Capybara::Webkit::ClickFailed,
           /\[@id='foo'\].*visible/
         )
@@ -461,7 +461,7 @@ describe Capybara::Session do
 
     it 'raises an error if an element is not in the viewport when clicked' do
       subject.visit('/')
-      lambda { subject.click_link "Click Me" }.should raise_error(Capybara::Webkit::ClickFailed)
+      expect { subject.click_link "Click Me" }.to raise_error(Capybara::Webkit::ClickFailed)
     end
 
     context "with wait time of 1 second" do
@@ -481,7 +481,7 @@ describe Capybara::Session do
           }, 400);
         JS
 
-        lambda { subject.click_link "Click Me" }.should_not raise_error
+        expect { subject.click_link "Click Me" }.not_to raise_error
       end
     end
   end
@@ -540,7 +540,7 @@ describe Capybara::Session do
       session.attach_file 'File', file.path
       session.click_on 'Go'
 
-      session.should have_text('Hello')
+      expect(session).to have_text('Hello')
     end
   end
 end

--- a/spec/selenium_compatibility_spec.rb
+++ b/spec/selenium_compatibility_spec.rb
@@ -40,7 +40,7 @@ describe Capybara::Webkit, 'compatibility with selenium' do
   end
 
   def compare_events_for_drivers(first, second, &block)
-    events_for_driver(first, &block).should == events_for_driver(second, &block)
+    expect(events_for_driver(first, &block)).to eq(events_for_driver(second, &block))
   end
 
   def events_for_driver(name, &block)


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec

* 284 conversions
    from: obj.should
      to: expect(obj).to

* 40 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 15 conversions
    from: =~ /pattern/
      to: match(/pattern/)

* 11 conversions
    from: lambda { }.should
      to: expect { }.to

* 9 conversions
    from: lambda { }.should_not
      to: expect { }.not_to

* 9 conversions
    from: obj.stub(:message)
      to: allow(obj).to receive(:message)

* 8 conversions
    from: == expected
      to: eq(expected)

* 3 conversions
    from: === expected
      to: be === expected

* 3 conversions
    from: obj.should_not_receive(:message)
      to: expect(obj).not_to receive(:message)

* 3 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 3 conversions
    from: obj.unstub(:message)
      to: allow(obj).to receive(:message).and_call_original

* 1 conversion
    from: Klass.any_instance.should_receive(:message)
      to: expect_any_instance_of(Klass).to receive(:message)

* 1 conversion
    from: Klass.any_instance.stub(:message)
      to: allow_any_instance_of(Klass).to receive(:message)

* 1 conversion
    from: its(:attr) { }
      to: describe '#attr' do subject { super().attr }; it { } end