### PR TITLE
Only attepting to kill if @pid is not nil

### DIFF
--- a/lib/capybara/webkit/connection.rb
+++ b/lib/capybara/webkit/connection.rb
@@ -67,9 +67,9 @@ module Capybara::Webkit
 
     def kill_process
       if RUBY_PLATFORM =~ /mingw32/
-        Process.kill(9, @pid) unless @pid.nil?
+        Process.kill(9, @pid)
       else
-        Process.kill("INT", @pid) unless @pid.nil?
+        Thread.kill(@wait_thr)
       end
     rescue Errno::ESRCH
       # This just means that the webkit_server process has already ended


### PR DESCRIPTION
Corrects Ruby error when attempting to kill the WebKit browser once it's already dead.
