### PR TITLE
Kill webkit_server when parent closes stdin

### DIFF
--- a/lib/capybara/webkit/connection.rb
+++ b/lib/capybara/webkit/connection.rb
@@ -52,27 +52,7 @@ module Capybara::Webkit
     end
 
     def open_pipe
-      _, @pipe_stdout, @pipe_stderr, @wait_thr = Open3.popen3(SERVER_PATH)
-      register_shutdown_hook
-    end
-
-    def register_shutdown_hook
-      @owner_pid = Process.pid
-      at_exit do
-        if Process.pid == @owner_pid
-          kill_process
-        end
-      end
-    end
-
-    def kill_process
-      if RUBY_PLATFORM =~ /mingw32/
-        Process.kill(9, @pid)
-      else
-        Process.kill("INT", @pid)
-      end
-    rescue Errno::ESRCH
-      # This just means that the webkit_server process has already ended
+      @pipe_stdin, @pipe_stdout, @pipe_stderr, @wait_thr = Open3.popen3(SERVER_PATH)
     end
 
     def discover_port

--- a/src/StdinNotifier.cpp
+++ b/src/StdinNotifier.cpp
@@ -1,0 +1,16 @@
+#include "StdinNotifier.h"
+
+#include <QTcpServer>
+
+StdinNotifier::StdinNotifier(QObject *parent) : QObject(parent) {
+  m_notifier = new QSocketNotifier(fileno(stdin), QSocketNotifier::Read, this);
+  connect(m_notifier, SIGNAL(activated(int)), this, SLOT(notifierActivated()));
+}
+
+void StdinNotifier::notifierActivated() {
+  std::string line;
+  std::getline(std::cin, line);
+  if (std::cin.eof()) {
+    emit eof();
+  }
+}

--- a/src/StdinNotifier.h
+++ b/src/StdinNotifier.h
@@ -1,0 +1,20 @@
+#include <QObject>
+
+class QSocketNotifier;
+
+class StdinNotifier : public QObject {
+  Q_OBJECT
+
+  public:
+    StdinNotifier(QObject *parent = 0);
+
+  public slots:
+    void notifierActivated();
+
+  signals:
+    void eof();
+
+  private:
+    QSocketNotifier *m_notifier;
+};
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "Server.h"
 #include "IgnoreDebugOutput.h"
+#include "StdinNotifier.h"
 #include <QApplication>
 #include <iostream>
 #ifdef Q_OS_UNIX
@@ -18,6 +19,9 @@ int main(int argc, char **argv) {
   app.setApplicationName("capybara-webkit");
   app.setOrganizationName("thoughtbot, inc");
   app.setOrganizationDomain("thoughtbot.com");
+
+  StdinNotifier notifier;
+  QObject::connect(&notifier, SIGNAL(eof()), &app, SLOT(quit()));
 
   ignoreDebugOutput();
   Server server(0);

--- a/src/webkit_server.pro
+++ b/src/webkit_server.pro
@@ -75,7 +75,8 @@ HEADERS = \
   JavascriptCommand.h \
   FindXpath.h \
   NetworkReplyProxy.h \
-  IgnoreDebugOutput.h
+  IgnoreDebugOutput.h \
+  StdinNotifier.h
 
 SOURCES = \
   GoForward.cpp \
@@ -147,7 +148,8 @@ SOURCES = \
   JavascriptCommand.cpp \
   FindXpath.cpp \
   NetworkReplyProxy.cpp \
-  IgnoreDebugOutput.cpp
+  IgnoreDebugOutput.cpp \
+  StdinNotifier.cpp
 
 RESOURCES = webkit_server.qrc
 QT += network


### PR DESCRIPTION
Alternative to #646. This should work cross-platform (tested on MRI and JRuby).
