### PR TITLE
Raise better errors if server fails to start

### DIFF
--- a/lib/capybara/webkit/connection.rb
+++ b/lib/capybara/webkit/connection.rb
@@ -55,9 +55,19 @@ module Capybara::Webkit
       @pipe_stdin, @pipe_stdout, @pipe_stderr, @wait_thr = Open3.popen3(SERVER_PATH)
     end
 
+    def parse_port(line)
+      if match = line.to_s.match(/listening on port: (\d+)/)
+        match[1].to_i
+      else
+        raise ConnectionError, "#{SERVER_PATH} failed to start."
+      end
+    end
+
     def discover_port
       if IO.select([@pipe_stdout], nil, nil, WEBKIT_SERVER_START_TIMEOUT)
-        @port = ((@pipe_stdout.first || '').match(/listening on port: (\d+)/) || [])[1].to_i
+        @port = parse_port(@pipe_stdout.first)
+      else
+        raise ConnectionError, "#{SERVER_PATH} failed to start after #{WEBKIT_SERVER_START_TIMEOUT} seconds."
       end
     end
 

--- a/lib/capybara/webkit/errors.rb
+++ b/lib/capybara/webkit/errors.rb
@@ -17,6 +17,9 @@ module Capybara::Webkit
   class NoSuchWindowError < StandardError
   end
 
+  class ConnectionError < StandardError
+  end
+
   class JsonError
     def initialize(response)
       error = JSON.parse response


### PR DESCRIPTION
When `WEBKIT_SERVER_START_TIMEOUT` was reached, `@port` would get set to `nil`. If execution of the `SERVER_PROCESS` returned immediately, `@port` would get set to `0`. This lead to odd cross-platform behavior in `#connect`, which would try to connect to a nonsense port.

Fixes #644.
