### PR TITLE
fix missed `browser_initialized?` method

### DIFF
--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -8,7 +8,7 @@ require "capybara/webkit/cookie_jar"
 require "capybara/webkit/errors"
 
 module Capybara::Webkit
-  class Driver
+  class Driver < Capybara::Driver::Base
     attr_reader :browser
 
     def initialize(app, options={})


### PR DESCRIPTION
Few weeks ago capybara introduced a new driver method that missed in our driver specification (https://github.com/jnicklas/capybara/issues/1237). 

After updating gems versions, I run tests and seen an exception: 

```
undefined method `browser_initialized?' for #<Capybara::Webkit::Driver:0xe9854a0>
```

We can resolve this and possible future updates just inherited from default web driver, for example, like it was implemented in poltergeist web driver (https://github.com/teampoltergeist/poltergeist/blob/master/lib/capybara/poltergeist/driver.rb#L4)
