### PR TITLE
Extract filter classes from NetworkAccessManager

### DIFF
--- a/src/BlacklistedRequestHandler.cpp
+++ b/src/BlacklistedRequestHandler.cpp
@@ -1,0 +1,48 @@
+#include "BlacklistedRequestHandler.h"
+#include "NetworkReplyProxy.h"
+#include "NoOpReply.h"
+
+BlacklistedRequestHandler::BlacklistedRequestHandler(
+  RequestHandler *next,
+  QObject *parent
+) : RequestHandler(parent) {
+  m_next = next;
+}
+
+QNetworkReply* BlacklistedRequestHandler::handleRequest(
+  NetworkAccessManager *manager,
+  QNetworkAccessManager::Operation operation,
+  QNetworkRequest &request,
+  QIODevice *outgoingData
+) {
+  if (this->isBlacklisted(request.url())) {
+    return new NetworkReplyProxy(new NoOpReply(request), this);
+  } else {
+    return m_next->handleRequest(manager, operation, request, outgoingData);
+  }
+}
+
+void BlacklistedRequestHandler::setUrlBlacklist(QStringList urlBlacklist) {
+  m_urlBlacklist.clear();
+
+  QStringListIterator iter(urlBlacklist);
+  while (iter.hasNext()) {
+    m_urlBlacklist << iter.next();
+  }
+}
+
+bool BlacklistedRequestHandler::isBlacklisted(QUrl url) {
+  QString urlString = url.toString();
+  QStringListIterator iter(m_urlBlacklist);
+
+  while (iter.hasNext()) {
+    QRegExp blacklisted = QRegExp(iter.next());
+    blacklisted.setPatternSyntax(QRegExp::Wildcard);
+
+    if(urlString.contains(blacklisted)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/BlacklistedRequestHandler.h
+++ b/src/BlacklistedRequestHandler.h
@@ -1,0 +1,20 @@
+#include <QStringList>
+
+#include "RequestHandler.h"
+
+class BlacklistedRequestHandler : public RequestHandler {
+  public:
+    BlacklistedRequestHandler(RequestHandler *next, QObject *parent = 0);
+    virtual QNetworkReply* handleRequest(
+      NetworkAccessManager *,
+      QNetworkAccessManager::Operation,
+      QNetworkRequest &,
+      QIODevice *
+    );
+    void setUrlBlacklist(QStringList urlBlacklist);
+
+  private:
+    RequestHandler *m_next;
+    QStringList m_urlBlacklist;
+    bool isBlacklisted(QUrl url);
+};

--- a/src/CustomHeadersRequestHandler.cpp
+++ b/src/CustomHeadersRequestHandler.cpp
@@ -1,0 +1,37 @@
+#include "CustomHeadersRequestHandler.h"
+#include "NetworkReplyProxy.h"
+#include "NoOpReply.h"
+
+CustomHeadersRequestHandler::CustomHeadersRequestHandler(
+  RequestHandler *next,
+  QObject *parent
+) : RequestHandler(parent) {
+  m_next = next;
+}
+
+QNetworkReply* CustomHeadersRequestHandler::handleRequest(
+  NetworkAccessManager *manager,
+  QNetworkAccessManager::Operation operation,
+  QNetworkRequest &request,
+  QIODevice *outgoingData
+) {
+  Q_UNUSED(manager)
+  Q_UNUSED(operation)
+  Q_UNUSED(outgoingData)
+
+  QHashIterator<QString, QString> item(m_headers);
+  while (item.hasNext()) {
+    item.next();
+    request.setRawHeader(item.key().toLatin1(), item.value().toLatin1());
+  }
+
+  return m_next->handleRequest(manager, operation, request, outgoingData);
+}
+
+void CustomHeadersRequestHandler::addHeader(QString key, QString value) {
+  m_headers.insert(key, value);
+}
+
+void CustomHeadersRequestHandler::reset() {
+  m_headers.clear();
+}

--- a/src/CustomHeadersRequestHandler.h
+++ b/src/CustomHeadersRequestHandler.h
@@ -1,0 +1,21 @@
+#include <QHash>
+#include <QString>
+
+#include "RequestHandler.h"
+
+class CustomHeadersRequestHandler : public RequestHandler {
+  public:
+    CustomHeadersRequestHandler(RequestHandler *next, QObject *parent = 0);
+    virtual QNetworkReply* handleRequest(
+      NetworkAccessManager *,
+      QNetworkAccessManager::Operation,
+      QNetworkRequest &,
+      QIODevice *
+    );
+    void addHeader(QString, QString);
+    virtual void reset();
+
+  private:
+    RequestHandler *m_next;
+    QHash<QString, QString> m_headers;
+};

--- a/src/Header.cpp
+++ b/src/Header.cpp
@@ -9,11 +9,10 @@ Header::Header(WebPageManager *manager, QStringList &arguments, QObject *parent)
 void Header::start() {
   QString key = arguments()[0];
   QString value = arguments()[1];
-  NetworkAccessManager* networkAccessManager = manager()->networkAccessManager();
   if (key.toLower().replace("-", "_") == "user_agent") {
     page()->setUserAgent(value);
   } else {
-    networkAccessManager->addHeader(key, value);
+    manager()->addHeader(key, value);
   }
   finish(true);
 }

--- a/src/MissingContentHeaderRequestHandler.cpp
+++ b/src/MissingContentHeaderRequestHandler.cpp
@@ -1,0 +1,23 @@
+#include "MissingContentHeaderRequestHandler.h"
+#include "NetworkReplyProxy.h"
+#include "NoOpReply.h"
+
+MissingContentHeaderRequestHandler::MissingContentHeaderRequestHandler(
+  RequestHandler *next,
+  QObject *parent
+) : RequestHandler(parent) {
+  m_next = next;
+}
+
+QNetworkReply* MissingContentHeaderRequestHandler::handleRequest(
+  NetworkAccessManager *manager,
+  QNetworkAccessManager::Operation operation,
+  QNetworkRequest &request,
+  QIODevice *outgoingData
+) {
+  if (operation != QNetworkAccessManager::PostOperation && operation != QNetworkAccessManager::PutOperation) {
+    request.setHeader(QNetworkRequest::ContentTypeHeader, QVariant());
+  }
+
+  return m_next->handleRequest(manager, operation, request, outgoingData);
+}

--- a/src/MissingContentHeaderRequestHandler.h
+++ b/src/MissingContentHeaderRequestHandler.h
@@ -1,0 +1,15 @@
+#include "RequestHandler.h"
+
+class MissingContentHeaderRequestHandler : public RequestHandler {
+  public:
+    MissingContentHeaderRequestHandler(RequestHandler *next, QObject *parent = 0);
+    virtual QNetworkReply* handleRequest(
+      NetworkAccessManager *,
+      QNetworkAccessManager::Operation,
+      QNetworkRequest &,
+      QIODevice *
+    );
+
+  private:
+    RequestHandler *m_next;
+};

--- a/src/NetworkAccessManager.h
+++ b/src/NetworkAccessManager.h
@@ -3,32 +3,37 @@
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkRequest>
 #include <QtNetwork/QNetworkReply>
-#include <QStringList>
+
+class RequestHandler;
 
 class NetworkAccessManager : public QNetworkAccessManager {
-
   Q_OBJECT
 
   public:
-    NetworkAccessManager(QObject *parent = 0);
-    void addHeader(QString key, QString value);
+    NetworkAccessManager(RequestHandler *, QObject *parent = 0);
     void reset();
     void setUserName(const QString &userName);
     void setPassword(const QString &password);
-    void setUrlBlacklist(QStringList urlBlacklist);
+    QNetworkReply* sendRequest(
+      QNetworkAccessManager::Operation,
+      const QNetworkRequest &,
+      QIODevice *
+    );
 
   protected:
-    QNetworkReply* createRequest(QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice * outgoingData);
+    QNetworkReply* createRequest(
+      QNetworkAccessManager::Operation,
+      const QNetworkRequest &,
+      QIODevice *
+    );
     QString m_userName;
     QString m_password;
-    QStringList m_urlBlacklist;
 
   private:
     void disableKeyChainLookup();
 
-    QHash<QString, QString> m_headers;
-    bool isBlacklisted(QUrl url);
     QHash<QUrl, QUrl> m_redirectMappings;
+    RequestHandler * m_requestHandler;
 
   private slots:
     void provideAuthentication(QNetworkReply *reply, QAuthenticator *authenticator);

--- a/src/NetworkRequestFactory.cpp
+++ b/src/NetworkRequestFactory.cpp
@@ -1,0 +1,15 @@
+#include "NetworkRequestFactory.h"
+#include "NetworkAccessManager.h"
+
+NetworkRequestFactory::NetworkRequestFactory(QObject *parent) :
+  RequestHandler(parent) {
+}
+
+QNetworkReply* NetworkRequestFactory::handleRequest(
+  NetworkAccessManager *manager,
+  QNetworkAccessManager::Operation operation,
+  QNetworkRequest &request,
+  QIODevice *outgoingData
+) {
+  return manager->sendRequest(operation, request, outgoingData);
+}

--- a/src/NetworkRequestFactory.h
+++ b/src/NetworkRequestFactory.h
@@ -1,0 +1,12 @@
+#include "RequestHandler.h"
+
+class NetworkRequestFactory : public RequestHandler {
+  public:
+    NetworkRequestFactory(QObject *parent = 0);
+    virtual QNetworkReply* handleRequest(
+      NetworkAccessManager *,
+      QNetworkAccessManager::Operation,
+      QNetworkRequest &,
+      QIODevice *
+    );
+};

--- a/src/NoOpReply.cpp
+++ b/src/NoOpReply.cpp
@@ -1,7 +1,7 @@
 #include <QTimer>
 #include "NoOpReply.h"
 
-NoOpReply::NoOpReply(QNetworkRequest &request, QObject *parent) : QNetworkReply(parent) {
+NoOpReply::NoOpReply(const QNetworkRequest &request, QObject *parent) : QNetworkReply(parent) {
   open(ReadOnly | Unbuffered);
   setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
   setHeader(QNetworkRequest::ContentLengthHeader, QVariant(0));

--- a/src/NoOpReply.h
+++ b/src/NoOpReply.h
@@ -5,7 +5,7 @@ class NoOpReply : public QNetworkReply {
   Q_OBJECT
 
   public: 
-    NoOpReply(QNetworkRequest &request, QObject *parent = 0);
+    NoOpReply(const QNetworkRequest &request, QObject *parent = 0);
 
     void abort();
     qint64 bytesAvailable() const;

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -1,0 +1,4 @@
+#include "RequestHandler.h"
+
+RequestHandler::RequestHandler(QObject *parent) : QObject(parent) {
+}

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -1,0 +1,25 @@
+#ifndef __REQUESTHANDLER_H
+#define __REQUESTHANDLER_H
+
+#include <QtNetwork/QNetworkAccessManager>
+#include <QtNetwork/QNetworkRequest>
+#include <QtNetwork/QNetworkReply>
+#include <QStringList>
+
+class NetworkAccessManager;
+
+class RequestHandler : public QObject {
+  Q_OBJECT
+
+  public:
+    RequestHandler(QObject *parent = 0);
+
+    virtual QNetworkReply* handleRequest(
+      NetworkAccessManager *,
+      QNetworkAccessManager::Operation,
+      QNetworkRequest &,
+      QIODevice *
+    ) = 0;
+};
+
+#endif

--- a/src/SetUrlBlacklist.cpp
+++ b/src/SetUrlBlacklist.cpp
@@ -8,8 +8,7 @@ SetUrlBlacklist::SetUrlBlacklist(WebPageManager *manager, QStringList &arguments
 }
 
 void SetUrlBlacklist::start() {
-  NetworkAccessManager* networkAccessManager = manager()->networkAccessManager();
-  networkAccessManager->setUrlBlacklist(arguments());
+  manager()->setUrlBlacklist(arguments());
   finish(true);
 }
 

--- a/src/SetUrlBlacklist.h
+++ b/src/SetUrlBlacklist.h
@@ -1,4 +1,3 @@
-
 #include "SocketCommand.h"
 
 class SetUrlBlacklist : public SocketCommand {
@@ -8,4 +7,3 @@ class SetUrlBlacklist : public SocketCommand {
   SetUrlBlacklist(WebPageManager *manager, QStringList &arguments, QObject *parent = 0);
   virtual void start();
 };
-

--- a/src/WebPageManager.h
+++ b/src/WebPageManager.h
@@ -10,6 +10,8 @@
 class WebPage;
 class NetworkCookieJar;
 class NetworkAccessManager;
+class BlacklistedRequestHandler;
+class CustomHeadersRequestHandler;
 
 class WebPageManager : public QObject {
   Q_OBJECT
@@ -33,6 +35,8 @@ class WebPageManager : public QObject {
     void enableLogging();
     void replyFinished(QNetworkReply *reply);
     NetworkAccessManager *networkAccessManager();
+    void setUrlBlacklist(const QStringList &);
+    void addHeader(QString, QString);
 
   public slots:
     void emitLoadStarted();
@@ -58,6 +62,8 @@ class WebPageManager : public QObject {
     QFile *m_ignoredOutput;
     int m_timeout;
     NetworkAccessManager *m_networkAccessManager;
+    BlacklistedRequestHandler *m_blacklistedRequestHandler;
+    CustomHeadersRequestHandler *m_customHeadersRequestHandler;
 };
 
 #endif // _WEBPAGEMANAGER_H

--- a/src/webkit_server.pro
+++ b/src/webkit_server.pro
@@ -78,7 +78,12 @@ HEADERS = \
   FindXpath.h \
   NetworkReplyProxy.h \
   IgnoreDebugOutput.h \
-  StdinNotifier.h
+  StdinNotifier.h \
+  RequestHandler.h \
+  BlacklistedRequestHandler.h \
+  MissingContentHeaderRequestHandler.h \
+  CustomHeadersRequestHandler.h \
+  NetworkRequestFactory.h
 
 SOURCES = \
   FindModal.cpp \
@@ -153,7 +158,12 @@ SOURCES = \
   FindXpath.cpp \
   NetworkReplyProxy.cpp \
   IgnoreDebugOutput.cpp \
-  StdinNotifier.cpp
+  StdinNotifier.cpp \
+  RequestHandler.cpp \
+  BlacklistedRequestHandler.cpp \
+  MissingContentHeaderRequestHandler.cpp \
+  CustomHeadersRequestHandler.cpp \
+  NetworkRequestFactory.cpp
 
 RESOURCES = webkit_server.qrc
 QT += network


### PR DESCRIPTION
NetworkAccessManager was getting pretty complex, and adding something that
modifies or intercepts requests is becoming a common change.

This change introduces a chain of filters which can modify a request or return
a response of their own.

To start with, this extracts the concerns of fixing missing content types,
setting custom headers, and intercepting blacklisted requests.
