### PR TITLE
Use pkgconfig to find the zlib and gl libraries.

### DIFF
--- a/src/webkit_server.pro
+++ b/src/webkit_server.pro
@@ -1,3 +1,5 @@
+CONFIG += link_pkgconfig
+PKGCONFIG = gl zlib
 TEMPLATE = app
 TARGET = webkit_server
 DESTDIR = .


### PR DESCRIPTION
As described in #695, this fixes installing `capybara-webkit` on NixOS.
