### PR TITLE
Expose INCLUDEPATH and LIBS qmake variables

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -1,2 +1,18 @@
+require 'mkmf'
+$CPPFLAGS = ""
+
+dir_config("gl")
+dir_config("zlib")
+
+includepath = $CPPFLAGS.gsub("-I", '').strip
+libs = $LIBPATH.map {|p| "-L#{p}"}.join(" ").strip
+
+unless includepath.empty?
+  ENV["CAPYBARA_WEBKIT_INCLUDEPATH"] = includepath
+end
+unless libs.empty?
+  ENV["CAPYBARA_WEBKIT_LIBS"] = libs
+end
+
 require File.join(File.expand_path(File.dirname(__FILE__)), "lib", "capybara_webkit_builder")
 CapybaraWebkitBuilder.build_all

--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -1,5 +1,6 @@
 require "fileutils"
 require "rbconfig"
+require "shellwords"
 
 module CapybaraWebkitBuilder
   extend self
@@ -52,8 +53,10 @@ module CapybaraWebkitBuilder
     success
   end
 
-  def makefile(config = '')
-    sh("#{qmake_bin} -spec #{spec} #{config}")
+  def makefile(*configs)
+    configs += default_configs
+    configs = configs.map {|c| c.shellescape}.join(" ")
+    sh("#{qmake_bin} -spec #{spec} #{configs}")
   end
 
   def qmake
@@ -80,6 +83,19 @@ module CapybaraWebkitBuilder
     File.open("Makefile", "w") do |file|
       file.print "all:\n\t@echo ok\ninstall:\n\t@echo ok"
     end
+  end
+
+  def default_configs
+    configs = []
+    libpath = ENV["CAPYBARA_WEBKIT_LIBS"]
+    cppflags = ENV["CAPYBARA_WEBKIT_INCLUDEPATH"]
+    if libpath
+      configs << "LIBS += #{libpath}"
+    end
+    if cppflags
+      configs << "INCLUDEPATH += #{cppflags}"
+    end
+    configs
   end
 
   def build_all


### PR DESCRIPTION
This allows one to specify the include and lib paths for gl and zlib.

Example:

```
gem install capybara-webkit -- \
  --with-gl-dir=/nix/store/1sw1cyny213ih9dpdsq8h2kwqaqcm6vp-mesa-10.2.9 \
  --with-zlib-dir=/nix/store/cb649pfdf14335d07jcfmsik7a1rsgbf-zlib-1.2.8
```

Fixes #695
