### PR TITLE
Clarify warnings for blocked requests

### DIFF
--- a/src/UnknownUrlHandler.cpp
+++ b/src/UnknownUrlHandler.cpp
@@ -23,12 +23,12 @@ QNetworkReply* UnknownUrlHandler::handleRequest(
     switch(m_mode) {
       case WARN:
         QTextStream(stderr) <<
-           "Unexpected request: " << url.toString() << endl <<
-           "To block unknown requests:" << endl <<
-           "  page.driver.block_unknown_requests" << endl <<
-           "To allow just this request:" << endl <<
+           "Request to unexpected url: " << url.toString() << endl <<
+           "To block requests to unknown urls:" << endl <<
+           "  page.driver.block_unknown_urls" << endl <<
+           "To allow just this url:" << endl <<
            "  page.driver.allow_url(\"" << url.toString() << "\")" << endl <<
-           "To allow allow requests from this host:" << endl <<
+           "To allow allow requests to urls from this host:" << endl <<
            "  page.driver.allow_url(\"" << url.host() << "\")" << endl;
         break;
       case BLOCK:


### PR DESCRIPTION
Most importantly, I believe `page.driver.block_unknown_requests` was renamed to `page.driver.block_unknown_urls`.