### PR TITLE
Fix returning invisible text on a hidden page

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -561,6 +561,24 @@ describe Capybara::Webkit::Driver do
     end
   end
 
+  context "hidden text app" do
+    let(:driver) do
+      driver_for_html(<<-HTML)
+        <html>
+          <body>
+            <h1 style="display: none">Hello</h1>
+          </body>
+        </html>
+      HTML
+    end
+
+    before { visit("/") }
+
+    it "has no visible text" do
+      driver.find_xpath("/html").first.text.should be_empty
+    end
+  end
+
   context "console messages app" do
     let(:driver) do
       driver_for_html(<<-HTML)

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -71,7 +71,8 @@ Capybara = {
     } else if (type == "textarea") {
       return node.innerHTML;
     } else {
-      return node.innerText || node.textContent;
+      visible_text = node.innerText;
+      return typeof visible_text === "string" ? visible_text : node.textContent;
     }
   },
 


### PR DESCRIPTION
Commit 2f3832fa153642a07649b6e449e3c2e70c6a5f9b introduced a bug wherein
if the entire page has hidden content, the entire page text is returned
as visible text. The bug was introduced to support SVG text handling.
The svg element doesn't have an innerText property, but does have
textContent property, so the patch was written to fallback on
textContent. The thing is, innerText will return an empty string when
there is no visible text on the screen, which is a falsey condition, so
we fall back to textContent. Thankfully, calling innerText on an svg
element returns undefined, so now we can confidently return the empty
string when it exists before falling back to textContent.

The patch could also be written as:

    return visible_text == undefined ? node.textContent : visible_text;

(double equals should work fine in this case)