### PR TITLE
Forward output from server pipes ASAP

### DIFF
--- a/lib/capybara/webkit/connection.rb
+++ b/lib/capybara/webkit/connection.rb
@@ -59,9 +59,9 @@ module Capybara::Webkit
 
     def start_server
       open_pipe
+      forward_output_in_background_thread
       discover_port
       discover_pid
-      forward_output_in_background_thread
     end
 
     def open_pipe

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -50,6 +50,17 @@ describe Capybara::Webkit::Connection do
       to raise_error(Capybara::Webkit::ConnectionError, error_string)
   end
 
+  it "gets stderr output if the server fails to start", skip_on_windows: true do
+    server_path = 'echo "A bad thing" >&2'
+    stub_const("Capybara::Webkit::Connection::SERVER_PATH", server_path)
+
+    read_io, write_io = IO.pipe
+    expect { Capybara::Webkit::Connection.new(:stderr => write_io) }.
+      to raise_error(Capybara::Webkit::ConnectionError)
+
+    expect(read_io).to include_response "A bad thing"
+  end
+
   it "boots a server to talk to" do
     url = "http://#{@rack_server.host}:#{@rack_server.port}/"
     connection.puts "Visit"


### PR DESCRIPTION
If the webkit server fails to start an error is raised before the output
forwarding is set up. Without output forwarding we don't get to see the
error from the server making it harder to debug.