### PR TITLE
Include the code that we need

### DIFF
--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -16,29 +16,14 @@ module CapybaraWebkitBuilder
     ENV['QMAKE'] || default_qmake_binary
   end
 
-  def spec
-    ENV['SPEC'] || os_spec
-  end
-
   def default_qmake_binary
     case RbConfig::CONFIG['host_os']
     when /freebsd/
       "qmake-qt4"
+    when /openbsd/
+      "qmake-qt5"
     else
       "qmake"
-    end
-  end
-
-  def os_spec
-    case RbConfig::CONFIG['host_os']
-    when /linux/
-      "linux-g++"
-    when /freebsd/
-      "freebsd-g++"
-    when /mingw32/
-      "win32-g++"
-    else
-      "macx-g++"
     end
   end
 

--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -41,7 +41,7 @@ module CapybaraWebkitBuilder
   def makefile(*configs)
     configs += default_configs
     configs = configs.map { |config| config.shellescape}.join(" ")
-    sh("#{qmake_bin} -spec #{spec} #{configs}")
+    sh("#{qmake_bin} #{configs}")
   end
 
   def qmake

--- a/spec/capybara_webkit_builder_spec.rb
+++ b/spec/capybara_webkit_builder_spec.rb
@@ -16,12 +16,6 @@ describe CapybaraWebkitBuilder do
     end
   end
 
-  it "will use the env variable for #os_spec" do
-    with_env_vars("SPEC" => "fake_os_spec") do
-      builder.spec.should == "fake_os_spec"
-    end
-  end
-
   it "defaults the #make_bin" do
     with_env_vars("MAKE_BIN" => nil) do
       builder.make_bin.should == 'make'
@@ -31,12 +25,6 @@ describe CapybaraWebkitBuilder do
   it "defaults the #qmake_bin" do
     with_env_vars("QMAKE" => nil) do
       builder.qmake_bin.should == 'qmake'
-    end
-  end
-
-  it "defaults #spec to the #os_specs" do
-    with_env_vars("SPEC" => nil) do
-      builder.spec.should == builder.os_spec
     end
   end
 end

--- a/src/StdinNotifier.cpp
+++ b/src/StdinNotifier.cpp
@@ -1,6 +1,7 @@
 #include "StdinNotifier.h"
 
 #include <QTcpServer>
+#include <iostream>
 
 StdinNotifier::StdinNotifier(QObject *parent) : QObject(parent) {
   m_notifier = new QSocketNotifier(fileno(stdin), QSocketNotifier::Read, this);

--- a/src/StdinNotifier.cpp
+++ b/src/StdinNotifier.cpp
@@ -1,6 +1,7 @@
 #include "StdinNotifier.h"
 
 #include <QTcpServer>
+#include <QSocketNotifier>
 #include <iostream>
 
 StdinNotifier::StdinNotifier(QObject *parent) : QObject(parent) {

--- a/src/StdinNotifier.h
+++ b/src/StdinNotifier.h
@@ -1,7 +1,6 @@
 #include <QObject>
 
 class QSocketNotifier;
-#include <QSocketNotifier>
 
 class StdinNotifier : public QObject {
   Q_OBJECT

--- a/src/StdinNotifier.h
+++ b/src/StdinNotifier.h
@@ -1,6 +1,7 @@
 #include <QObject>
 
 class QSocketNotifier;
+#include <QSocketNotifier>
 
 class StdinNotifier : public QObject {
   Q_OBJECT

--- a/src/WebPage.h
+++ b/src/WebPage.h
@@ -1,5 +1,6 @@
 #ifndef _WEBPAGE_H
 #define _WEBPAGE_H
+#include <QtGlobal>
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWebKitWidgets>
 #else


### PR DESCRIPTION
- `cin` and `cout` require iostream.
- `QT_VERSION` requires QtGlobal.
- `QSocketNotifier` requires QSocketNotifier.
- Unrelated to includes: let Qt figure out the spec.

Found by Jeremy Evans on behalf of the OpenBSD project.