### PR TITLE
Support Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.1
+  - 2.2
   - jruby-19mode
 notifications:
   email: false


### PR DESCRIPTION
This adds Ruby 2.2 to Travis, replacing 2.1. I'm thinking it's fairly
safe that 2.1 works if both 1.9 and 2.2 are fine.