### PR TITLE
Reset Basic Authentication within same driver lifespan

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -2566,6 +2566,16 @@ CACHE MANIFEST
       lambda { visit("/") }.should_not raise_error
       driver.status_code.should eq 401
     end
+
+    it "can be reset with subsequent authenticate call", skip_on_qt4: true do
+      driver.browser.authenticate('user', 'password')
+      visit("/")
+      driver.html.should include("Basic "+Base64.encode64("user:password").strip)
+      driver.browser.authenticate('user1', 'password1')
+      driver.browser.timeout = 2
+      lambda { visit("/") }.should_not raise_error
+      driver.status_code.should eq 401      
+    end
   end
 
   describe "url blacklisting", skip_if_offline: true do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,11 @@ RSpec.configure do |c|
   c.filter_run_excluding :skip_on_jruby => !defined?(::JRUBY_VERSION).nil?
   c.filter_run_excluding :selenium_compatibility => (Capybara::VERSION =~ /^2\.4\./).nil?
   c.filter_run_excluding :skip_if_offline => !has_internet?
+  
+  #Check for QT version is 4 to skip QT5 required specs
+  #This should be removed once support for QT4 is dropped
+  require 'capybara_webkit_builder'
+  c.filter_run_excluding :skip_on_qt4 => !(%x(#{CapybaraWebkitBuilder.qmake_bin} -v).match(/Using Qt version 4/)).nil?
 
   # We can't support outerWidth and outerHeight without a visible window.
   # We focus the next window instead of failing when closing windows.

--- a/src/Authenticate.cpp
+++ b/src/Authenticate.cpp
@@ -11,6 +11,10 @@ void Authenticate::start() {
   QString password = arguments()[1];
 
   NetworkAccessManager* networkAccessManager = manager()->networkAccessManager();
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    //Reset Authentication cache
+    networkAccessManager->clearAccessCache();
+  #endif
   networkAccessManager->setUserName(username);
   networkAccessManager->setPassword(password);
 


### PR DESCRIPTION
As mentioned in #735 , provide ability to change basic authentication credentials within the same driver lifespan.