### PR TITLE
Fix reset crash when replies are destroyed

### DIFF
--- a/spec/support/app_runner.rb
+++ b/spec/support/app_runner.rb
@@ -25,10 +25,10 @@ module AppRunner
     AppRunner.app = app
   end
 
-  def driver_for_app(&body)
+  def driver_for_app(*driver_args, &body)
     app = Class.new(ExampleApp, &body)
     run_application app
-    build_driver
+    build_driver(*driver_args)
   end
 
   def driver_for_html(html, *driver_args)

--- a/src/WebPageManager.cpp
+++ b/src/WebPageManager.cpp
@@ -89,6 +89,11 @@ void WebPageManager::requestCreated(QByteArray &url, QNetworkReply *reply) {
   else {
     m_pendingReplies.append(reply);
     connect(reply, SIGNAL(finished()), SLOT(handleReplyFinished()));
+    connect(
+      reply,
+      SIGNAL(destroyed(QObject *)),
+      SLOT(replyDestroyed(QObject *))
+    );
   }
 }
 
@@ -102,6 +107,10 @@ void WebPageManager::replyFinished(QNetworkReply *reply) {
   int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
   logger() << "Received" << status << "from" << reply->url().toString();
   m_pendingReplies.removeAll(reply);
+}
+
+void WebPageManager::replyDestroyed(QObject *reply) {
+  m_pendingReplies.removeAll((QNetworkReply *) reply);
 }
 
 void WebPageManager::setPageStatus(bool success) {

--- a/src/WebPageManager.h
+++ b/src/WebPageManager.h
@@ -48,6 +48,7 @@ class WebPageManager : public QObject {
     void setPageStatus(bool);
     void requestCreated(QByteArray &url, QNetworkReply *reply);
     void handleReplyFinished();
+    void replyDestroyed(QObject *);
 
   signals:
     void pageFinished(bool);


### PR DESCRIPTION
We attempted to track in-progress replies and abort them in 1.5.1.
However, sometimes these replies are destroyed unexpectedly, so
attempting to abort them raises errors.

This commit tracks when replies are destroyed and removes them from the
queue of in-progress replies.