### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ development toolkit. You'll need to download the Qt libraries to build and
 install the gem. You can find instructions for downloading and installing QT on
 the
 [capybara-webkit wiki](https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit).
-capybara-webkit requires Qt version 4.8 or greater.
+capybara-webkit requires Qt version 5.
 
 Windows Support
 ---------------


### PR DESCRIPTION
Update the README to reflect the fact that Capybara Webkit now requires Qt 5.