### PR TITLE
Remove auto-screenshot behavior

### DIFF
--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -419,10 +419,6 @@ describe Capybara::Session do
         subject.find(:css, '#one').click
       }.to raise_error(Capybara::Webkit::ClickFailed) { |exception|
         exception.message.should =~ %r{Failed.*\[@id='one'\].*overlapping.*\[@id='two'\].*at position}
-        screenshot_pattern = %r{A screenshot of the page at the time of the failure has been written to (.*)}
-        exception.message.should =~ screenshot_pattern
-        file = exception.message.match(screenshot_pattern)[1]
-        File.exist?(file).should be_true
       }
     end
 

--- a/src/JavascriptInvocation.cpp
+++ b/src/JavascriptInvocation.cpp
@@ -135,14 +135,3 @@ void JavascriptInvocation::keypress(QChar key) {
   event = QKeyEvent(QKeyEvent::KeyRelease, keyCode, Qt::NoModifier, key);
   QApplication::sendEvent(m_page, &event);
 }
-
-const QString JavascriptInvocation::render(void) {
-  QString pathTemplate =
-    QDir::temp().absoluteFilePath("./click_failed_XXXXXX.png");
-  QTemporaryFile file(pathTemplate);
-  file.open();
-  file.setAutoRemove(false);
-  QString path = file.fileName();
-  m_page->render(path, QSize(1024, 768));
-  return path;
-}

--- a/src/JavascriptInvocation.h
+++ b/src/JavascriptInvocation.h
@@ -26,7 +26,6 @@ class JavascriptInvocation : public QObject {
     Q_INVOKABLE QVariantMap clickPosition(QWebElement element, int left, int top, int width, int height);
     Q_INVOKABLE void hover(int absoluteX, int absoluteY);
     Q_INVOKABLE void keypress(QChar);
-    Q_INVOKABLE const QString render(void);
     QVariant getError();
     void setError(QVariant error);
     InvocationResult invoke(QWebFrame *);

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -421,7 +421,6 @@ Capybara.ClickFailed = function(expectedPath, actualPath, position) {
     this.message += ' at position ' + position["absoluteX"] + ', ' + position["absoluteY"];
   else
     this.message += ' at unknown position';
-  this.message += "; \nA screenshot of the page at the time of the failure has been written to " + CapybaraInvocation.render();
 };
 Capybara.ClickFailed.prototype = new Error();
 Capybara.ClickFailed.prototype.constructor = Capybara.ClickFailed;


### PR DESCRIPTION
We can't distinguish between ClickFailed errors which will be retried,
and those which have actually failed for good. This means we end up
writing hundreds of screenshot files during a failure, and we sometimes
write several screenshot files even when the click ends up working.

This isn't feasible to work around in a driver, so this commit removes
the behavior from capybara-webkit. Something like this may make more
sense in Capybara proper.

Resolves #626.