### PR TITLE
Make click_failed_*.png world-readable

### DIFF
--- a/src/JavascriptInvocation.cpp
+++ b/src/JavascriptInvocation.cpp
@@ -141,6 +141,7 @@ const QString JavascriptInvocation::render(void) {
     QDir::temp().absoluteFilePath("./click_failed_XXXXXX.png");
   QTemporaryFile file(pathTemplate);
   file.open();
+  file.setPermissions(QFile::ReadUser | QFile::WriteUser | QFile::ReadGroup | QFile::ReadOther);
   file.setAutoRemove(false);
   QString path = file.fileName();
   m_page->render(path, QSize(1024, 768));


### PR DESCRIPTION
When we run tests using capybara-webkit in CI server, all users should
be able to read click_failed_*.png for debugging.