### PR TITLE
Don't deprecate allow_url and block_url

### DIFF
--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -21,12 +21,10 @@ module Capybara::Webkit
     end
 
     def allow_url(url)
-      deprecate_and_replace_with_config "allow_url", "allow_url(#{url.inspect})"
       @browser.allow_url(url)
     end
 
     def block_url(url)
-      deprecate_and_replace_with_config "block_url", "block_url(#{url.inspect})"
       @browser.block_url(url)
     end
 


### PR DESCRIPTION
I'd like to achieve these requirements:

- All unknown urls are blocked by default (`config.block_urls`)
- Allow some urls only in several test cases
  - I'd like to write `page.driver.allow_url('example.com')` at the
    beginning of such test cases.