### PR TITLE
Fix deprecation warnings in have_errors

### DIFF
--- a/lib/capybara/webkit/matchers.rb
+++ b/lib/capybara/webkit/matchers.rb
@@ -7,11 +7,20 @@ module Capybara
           actual.error_messages.any?
         end
 
-        failure_message_for_should do |actual|
+        # Check that RSpec is < 2.99
+        if !respond_to?(:failure_message) && respond_to?(:failure_message_for_should)
+          alias :failure_message :failure_message_for_should
+        end
+
+        if !respond_to?(:failure_message_when_negated) && respond_to?(:failure_message_for_should_not)
+          alias :failure_message_when_negated :failure_message_for_should_not
+        end
+
+        failure_message do |actual|
           "Expected Javascript errors, but there were none."
         end
-        
-        failure_message_for_should_not do |actual|
+
+        failure_message_when_negated do |actual|
           actual = resolve(actual)
           "Expected no Javascript errors, got:\n#{error_messages_for(actual)}"
         end

--- a/lib/capybara/webkit/matchers.rb
+++ b/lib/capybara/webkit/matchers.rb
@@ -9,12 +9,12 @@ module Capybara
 
         # Check that RSpec is < 2.99
         if !respond_to?(:failure_message) &&
-           respond_to?(:failure_message_for_should)
+          respond_to?(:failure_message_for_should)
           alias :failure_message :failure_message_for_should
         end
 
         if !respond_to?(:failure_message_when_negated) &&
-           respond_to?(:failure_message_for_should_not)
+          respond_to?(:failure_message_for_should_not)
           alias :failure_message_when_negated :failure_message_for_should_not
         end
 

--- a/lib/capybara/webkit/matchers.rb
+++ b/lib/capybara/webkit/matchers.rb
@@ -8,15 +8,17 @@ module Capybara
         end
 
         # Check that RSpec is < 2.99
-        if !respond_to?(:failure_message) && respond_to?(:failure_message_for_should)
+        if !respond_to?(:failure_message) &&
+           respond_to?(:failure_message_for_should)
           alias :failure_message :failure_message_for_should
         end
 
-        if !respond_to?(:failure_message_when_negated) && respond_to?(:failure_message_for_should_not)
+        if !respond_to?(:failure_message_when_negated) &&
+           respond_to?(:failure_message_for_should_not)
           alias :failure_message_when_negated :failure_message_for_should_not
         end
 
-        failure_message do |actual|
+        failure_message do |_actual|
           "Expected Javascript errors, but there were none."
         end
 

--- a/lib/capybara/webkit/matchers.rb
+++ b/lib/capybara/webkit/matchers.rb
@@ -9,12 +9,12 @@ module Capybara
 
         # Check that RSpec is < 2.99
         if !respond_to?(:failure_message) &&
-          respond_to?(:failure_message_for_should)
+            respond_to?(:failure_message_for_should)
           alias :failure_message :failure_message_for_should
         end
 
         if !respond_to?(:failure_message_when_negated) &&
-          respond_to?(:failure_message_for_should_not)
+            respond_to?(:failure_message_for_should_not)
           alias :failure_message_when_negated :failure_message_for_should_not
         end
 


### PR DESCRIPTION
Fix the issue https://github.com/thoughtbot/capybara-webkit/issues/670

credit to @bryanrite - this is copying the work he did on cancancan https://github.com/CanCanCommunity/cancancan/commit/9ca88d7f
