### PR TITLE
added browser_initialized? method to the driver

### DIFF
--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -325,6 +325,10 @@ module Capybara::Webkit
       @browser
     end
 
+    def browser_initialized?
+      !@browser.nil?
+    end
+
     private
 
     def modal_action_options_for_browser(options)


### PR DESCRIPTION
We came across the following issue while running cucumber tests:

      undefined method `browser_initialized?' for #<Capybara::Webkit::Driver:0x007f698bb9e3c0> (NoMethodError)
      /home/runner/test/vendor/bundle/ruby/2.2.0/gems/capybara-2.6.0/lib/capybara/session.rb:109:in `reset!'
      /home/runner/test/vendor/bundle/ruby/2.2.0/gems/capybara-2.6.0/lib/capybara.rb:285:in `block in reset_sessions!'
      /home/runner/test/vendor/bundle/ruby/2.2.0/gems/capybara-2.6.0/lib/capybara.rb:285:in `each'
      /home/runner/test/vendor/bundle/ruby/2.2.0/gems/capybara-2.6.0/lib/capybara.rb:285:in `reset_sessions!'
      /home/runner/test/vendor/bundle/ruby/2.2.0/gems/capybara-2.6.0/lib/capybara/cucumber.rb:8:in `After'


Capybara drivers implemented `browser_initialized?` method with this commit: https://github.com/jnicklas/capybara/commit/5665396fc99fe73340e88998ffa7a4d2eda6ffa2

So I added the same method here.
