### PR TITLE
Add basic send_keys implementation

### DIFF
--- a/lib/capybara/webkit/node.rb
+++ b/lib/capybara/webkit/node.rb
@@ -47,6 +47,21 @@ module Capybara::Webkit
       invoke "set", *[value].flatten
     end
 
+    def send_keys(*keys)
+      invoke("sendKeys", keys.map { |key|
+        case key
+        when :space
+          " "
+        when :enter
+          "\r"
+        when String
+          key.to_s
+        else
+          raise Capybara::NotSupportedByDriverError.new
+        end
+      }.join)
+    end
+
     def select_option
       invoke "selectOption"
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,9 +49,11 @@ RSpec.configure do |c|
 
   # We can't support outerWidth and outerHeight without a visible window.
   # We focus the next window instead of failing when closing windows.
-  # Node #send_keys is not yet implemented.
   c.filter_run_excluding :full_description => lambda { |description, metadata|
-    description =~ /Capybara::Session webkit Capybara::Window #(size|resize_to|maximize|close.*no_such_window_error|send_keys)/ || description =~ /Capybara::Session webkit node #send_keys/
+    (description !~ /Capybara::Session webkit node #send_keys should send a string of keys to an element/) && (
+      description =~ /Capybara::Session webkit Capybara::Window #(size|resize_to|maximize|close.*no_such_window_error|send_keys)/ ||
+      description =~ /Capybara::Session webkit node #send_keys/
+    )
   }
 end
 

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -269,6 +269,20 @@ Capybara = {
     return true;
   },
 
+  sendKeys: function (index, keys) {
+    var strindex, length;
+
+    length = keys.length;
+
+    if (length) {
+      this.focus(index);
+    }
+
+    for (strindex = 0; strindex < length; strindex++) {
+      CapybaraInvocation.keypress(keys[strindex]);
+    }
+  },
+
   set: function (index, value) {
     var length, maxLength, node, strindex, textTypes, type;
 
@@ -293,8 +307,9 @@ Capybara = {
           CapybaraInvocation.keypress(value[strindex]);
         }
 
-        if (value == '')
+        if (value === "") {
           this.trigger(index, "change");
+        }
       }
     } else if (type === "checkbox" || type === "radio") {
       if (node.checked != (value === "true")) {


### PR DESCRIPTION
This only supports simple strings, and arrays of simple strings. No modifiers and _very_ limited symbol support (`:enter` and `:space`).

It is however a start, and solves the problem of sending enter keys to `[contenteditable]` which was my original problem.