### PR TITLE
Allow returning JS Date objects

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -479,6 +479,11 @@ describe Capybara::Webkit::Driver do
       result.should eq nil
     end
 
+    it "evaluates Javascript and returns a date" do
+      result = driver.evaluate_script(%<new Date("2016-04-01T00:00:00Z")>)
+      result.should eq "2016-04-01T00:00:00Z"
+    end
+
     it "evaluates Javascript and returns an object" do
       result = driver.evaluate_script(%<({ 'one' : 1 })>)
       result.should eq 'one' => 1

--- a/src/JsonSerializer.cpp
+++ b/src/JsonSerializer.cpp
@@ -13,9 +13,9 @@ void JsonSerializer::addVariant(const QVariant &object) {
   if (object.isValid()) {
     switch(object.type()) {
       case QMetaType::QString:
+      case QMetaType::QDateTime:
         {
-          QString string = object.toString();
-          addString(string);
+          addString(object.toString());
         }
         break;
       case QMetaType::QVariantList:
@@ -44,11 +44,6 @@ void JsonSerializer::addVariant(const QVariant &object) {
       case QMetaType::Int:
         {
           m_buffer.append(object.toString());
-          break;
-        }
-      case QMetaType::QDateTime:
-        {
-          addString(object.toString());
           break;
         }
       default:

--- a/src/JsonSerializer.cpp
+++ b/src/JsonSerializer.cpp
@@ -46,6 +46,11 @@ void JsonSerializer::addVariant(const QVariant &object) {
           m_buffer.append(object.toString());
           break;
         }
+      case QMetaType::QDateTime:
+        {
+          addString(object.toString());
+          break;
+        }
       default:
         m_buffer.append("null");
     }


### PR DESCRIPTION
Rather then coercing JS Date objects to nil, send back their ISO string representation, just as Selenium does.

fixes #892