### PR TITLE
Deprecate webkit_debug driver

### DIFF
--- a/lib/capybara/webkit.rb
+++ b/lib/capybara/webkit.rb
@@ -16,6 +16,14 @@ Capybara.register_driver :webkit do |app|
 end
 
 Capybara.register_driver :webkit_debug do |app|
+  warn "[DEPRECATION] The webkit_debug driver is deprecated. " \
+    "Please use Capybara::Webkit.configure instead:\n\n" \
+    "  Capybara::Webkit.configure do |config|\n" \
+    "    config.debug = true\n" \
+    "  end\n\n" \
+    "This option is global and can be configured once" \
+    " (not in a `before` or `setup` block)."
+
   Capybara::Webkit::Driver.new(
     app,
     Capybara::Webkit::Configuration.to_hash.merge(debug: true)


### PR DESCRIPTION
There's a configuration setting for this and having multiple, registered
drivers adds unnecessary complications.