### PR TITLE
Move stderr option to config

### DIFF
--- a/lib/capybara/webkit/configuration.rb
+++ b/lib/capybara/webkit/configuration.rb
@@ -27,6 +27,7 @@ module Capybara
       attr_accessor :debug
       attr_writer :ignore_ssl_errors
       attr_accessor :proxy
+      attr_accessor :stderr
       attr_accessor :timeout
       attr_writer :skip_image_loading
 
@@ -38,6 +39,7 @@ module Capybara
         @ignore_ssl_errors = false
         @proxy = nil
         @skip_image_loading = false
+        @stderr = $stderr
         @timeout = -1
       end
 
@@ -90,6 +92,7 @@ module Capybara
           ignore_ssl_errors: ignore_ssl_errors?,
           proxy: proxy,
           skip_image_loading: skip_image_loading?,
+          stderr: stderr,
           timeout: timeout
         }
       end

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -1826,13 +1826,14 @@ describe Capybara::Webkit::Driver do
 
   context "no response app" do
     let(:driver) do
-      driver_for_html(<<-HTML, browser: browser)
+      driver_for_html(<<-HTML)
         <html><body>
           <form action="/error"><input type="submit"/></form>
         </body></html>
       HTML
     end
 
+    let!(:connection) { fork_connection }
     before { visit("/") }
 
     it "raises a webkit error for the requested url" do
@@ -1855,9 +1856,6 @@ describe Capybara::Webkit::Driver do
       connection.stub(:puts)
       connection.stub(:print)
     end
-
-    let(:browser) { Capybara::Webkit::Browser.new(connection) }
-    let(:connection) { Capybara::Webkit::Connection.new }
   end
 
   context "custom font app" do
@@ -2727,7 +2725,7 @@ CACHE MANIFEST
   describe "url whitelisting", skip_if_offline: true do
     it_behaves_like "output writer" do
       let(:driver) do
-        driver_for_html(<<-HTML, browser: browser)
+        driver_for_html(<<-HTML)
           <<-HTML
             <html>
               <body>
@@ -2890,7 +2888,7 @@ CACHE MANIFEST
   describe "logger app" do
     it_behaves_like "output writer" do
       let(:driver) do
-        driver_for_html("<html><body>Hello</body></html>", browser: browser)
+        driver_for_html("<html><body>Hello</body></html>")
       end
 
       it "logs nothing in normal mode" do
@@ -3071,7 +3069,7 @@ CACHE MANIFEST
     it_behaves_like "output writer" do
       let(:driver) do
         count = 0
-        driver_for_app browser: browser do
+        driver_for_app do
           get "/" do
             count += 1
             <<-HTML
@@ -3116,17 +3114,15 @@ CACHE MANIFEST
 
   context "when the driver process crashes" do
     let(:driver) do
-      driver_for_app browser: browser do
+      driver_for_app do
         get "/" do
           "<html><body>Relaunched</body></html>"
         end
       end
     end
 
-    let(:browser) { Capybara::Webkit::Browser.new(connection) }
-    let(:connection) { Capybara::Webkit::Connection.new }
-
     it "reports and relaunches on reset" do
+      connection = fork_connection
       Process.kill "KILL", connection.pid
       expect { driver.reset! }.to raise_error(Capybara::Webkit::CrashError)
       visit "/"
@@ -3162,6 +3158,8 @@ CACHE MANIFEST
           conn.close
         end
       end
+
+      fork_connection
     end
 
     after do
@@ -3195,9 +3193,7 @@ CACHE MANIFEST
       end
     end
 
-    let(:driver) { driver_for_html("", browser: browser) }
-    let(:browser) { Capybara::Webkit::Browser.new(connection) }
-    let(:connection) { Capybara::Webkit::Connection.new }
+    let(:driver) { driver_for_html("") }
   end
 
   context "skip image loading" do
@@ -3300,6 +3296,8 @@ CACHE MANIFEST
         config.use_proxy host: @host, port: @port, user: @user, pass: @pass
       end
 
+      fork_connection
+
       driver.visit @url
       @proxy_requests.size.should eq 2
       @request = @proxy_requests[-1]
@@ -3311,7 +3309,7 @@ CACHE MANIFEST
     end
 
     let(:driver) do
-      driver_for_html("", browser: nil)
+      driver_for_html("")
     end
 
     it "uses the HTTP proxy correctly" do

--- a/spec/support/app_runner.rb
+++ b/spec/support/app_runner.rb
@@ -5,7 +5,7 @@ require 'sinatra/base'
 
 module AppRunner
   class << self
-    attr_accessor :app, :app_host, :configuration
+    attr_accessor :app, :app_host, :browser, :configuration
   end
 
   def self.boot
@@ -20,6 +20,8 @@ module AppRunner
       [200, { 'Content-Type' => 'html', 'Content-Length' => 0 }, []]
     end
 
+    self.browser = $webkit_browser
+
     self.configuration = Capybara::Webkit::Configuration.new
   end
 
@@ -31,15 +33,25 @@ module AppRunner
     yield AppRunner.configuration
   end
 
-  def driver_for_app(*driver_args, &body)
-    app = Class.new(ExampleApp, &body)
-    run_application app
-    build_driver(*driver_args)
+  def fork_connection
+    AppRunner.fork_connection
   end
 
-  def driver_for_html(html, *driver_args)
+  def self.fork_connection
+    connection = Capybara::Webkit::Connection.new(options)
+    AppRunner.browser = Capybara::Webkit::Browser.new(connection)
+    connection
+  end
+
+  def driver_for_app(&body)
+    app = Class.new(ExampleApp, &body)
+    run_application app
+    AppRunner.build_driver
+  end
+
+  def driver_for_html(html)
     run_application_for_html html
-    build_driver(*driver_args)
+    AppRunner.build_driver
   end
 
   def session_for_app(&body)
@@ -54,15 +66,14 @@ module AppRunner
     }
   end
 
-  private
-
-  def build_driver(overrides = {})
-    options = AppRunner.configuration.
-      to_hash.
-      merge(browser: $webkit_browser).
-      merge(overrides)
-    Capybara::Webkit::Driver.new(AppRunner.app, options)
+  def self.build_driver
+    Capybara::Webkit::Driver.new(app, options.merge(browser: browser))
   end
+
+  def self.options
+    configuration.to_hash
+  end
+  private_class_method :options
 
   def self.included(example_group)
     example_group.class_eval do

--- a/spec/support/output_writer.rb
+++ b/spec/support/output_writer.rb
@@ -1,11 +1,8 @@
 shared_examples_for "output writer" do
   before do
     @read, @write = IO.pipe
-  end
-
-  let(:browser) do
-    connection = Capybara::Webkit::Connection.new(:stderr => @write)
-    Capybara::Webkit::Browser.new(connection)
+    configure { |config| config.stderr = @write }
+    fork_connection
   end
 
   let(:stderr) do


### PR DESCRIPTION
This is another option we missed when moving things into the
Configuration object.

I had to make substantial changes to the tests, because many of them
were using the stderr option for new connections. However, I think the
end result is actually cleaner.