### PR TITLE
Gitignore src/build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ webkit_server.pro.user
 .idea
 .qmake.stash
 gemfiles/*.lock
+/src/build/


### PR DESCRIPTION
`rake build` generates /src/build and should be ignored from version control