### PR TITLE
Gitignore bundler-generated binstubs (/bin)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ webkit_server.pro.user
 .idea
 .qmake.stash
 gemfiles/*.lock
+/bin


### PR DESCRIPTION
Development binstubs are expected to be in /bin (either via `bundle
install --binstubs` or `bundle binstubs <gem>`) but they shouldn't be
committed to git.

/bin/Info.plist is already added to git, so this change will not affect
its status as a versioned file.
