### PR TITLE
use proper options to create connection object

### DIFF
--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -13,7 +13,7 @@ module Capybara::Webkit
       @app = app
       @options = options.dup
       @options[:server] ||= Server.new(options)
-      @browser = options[:browser] || Browser.new(Connection.new(options))
+      @browser = options[:browser] || Browser.new(Connection.new(@options))
       apply_options
     end
 

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -16,6 +16,15 @@ describe Capybara::Webkit::Driver do
     "#{AppRunner.app_host}#{path}"
   end
 
+  context "configuration" do
+    let(:options) { AppRunner.configuration.to_hash }
+
+    it "configures server automatically" do
+      expect { Capybara::Webkit::Driver.new(AppRunner.app, options) }.
+        to_not raise_error
+    end
+  end
+
   context "iframe app" do
     let(:driver) do
       driver_for_app do


### PR DESCRIPTION
Looks like driver cannot create server automatically because `:server` option is added to a wrong hash. It breaks all my tests, because I'm using default driver setup.