### PR TITLE
Capybara::Webkit::Connection requires :server option

### DIFF
--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -13,7 +13,7 @@ module Capybara::Webkit
       @app = app
       @options = options.dup
       @options[:server] ||= Server.new(options)
-      @browser = options[:browser] || Browser.new(Connection.new(options))
+      @browser = options[:browser] || Browser.new(Connection.new(@options.dup))
       apply_options
     end
 


### PR DESCRIPTION
This bug was introduced in 753348ecb40b133e174225d8bd8b8ed900d2a2c2 .