### PR TITLE
Allow Qt 5.6 with QtWebKit module

### DIFF
--- a/src/webkit_server.pro
+++ b/src/webkit_server.pro
@@ -176,10 +176,11 @@ SOURCES = \
 RESOURCES = webkit_server.qrc
 QT += network
 greaterThan(QT_MAJOR_VERSION, 4) {
-  greaterThan(QT_MAJOR_VERSION, 5) | greaterThan(QT_MINOR_VERSION, 5) {
-    error(capybara-webkit does not support Qt versions greater than 5.5)
-  }
-  QT += webkitwidgets
+  qtHaveModule(webkitwidgets) {
+    QT += webkitwidgets
+   } else {
+      error("No QtWebKit installation found. QtWebKit is no longer included with Qt 5.6, so you may need to install it separately.")
+   }
 } else {
   QT += webkit
 }

--- a/test/testwebkitserver.pro
+++ b/test/testwebkitserver.pro
@@ -1,5 +1,5 @@
 SOURCES = testignoredebugoutput.cpp
-OBJECTS += ../src/IgnoreDebugOutput.o
+OBJECTS += ../src/build/IgnoreDebugOutput.o
 QT += testlib
 CONFIG += testcase console
 CONFIG -= app_bundle


### PR DESCRIPTION
If users compiled or otherwise installed the webkit module, this allows them to use capybara-webkit with Qt 5.6.

If they're using Qt 5.6 but don't have the module, this prints a friendlier error message.