### PR TITLE
Use the Fusion Qt Style

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,10 @@ int main(int argc, char **argv) {
   }
 #endif
 
+#ifdef Q_OS_MAC
+  QApplication::setStyle(QStyleFactory::create("Fusion"));
+#endif
+
   QApplication app(argc, argv);
   app.setApplicationName("capybara-webkit");
   app.setOrganizationName("thoughtbot, inc");


### PR DESCRIPTION
This fixes issues with checkboxes and radio buttons not being rendered
at the appropriate location on newer version of OS X.

Resolves #871.