### PR TITLE
Make sure to include QStyleFactory before using

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "IgnoreDebugOutput.h"
 #include "StdinNotifier.h"
 #include <QApplication>
+#include <QStyleFactory>
 #include <iostream>
 #ifdef Q_OS_UNIX
   #include <unistd.h>


### PR DESCRIPTION
This seems to be included as a side effect of something else on Qt 5,
but must be included directly in Qt 4.8.