### PR TITLE
Prepend logger() info with current time

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -24,7 +24,7 @@ Connection::Connection(QTcpSocket *socket, WebPageManager *manager, QObject *par
 }
 
 void Connection::commandReady(Command *command) {
-  m_manager->logger() << "Received" << command->toString();
+  m_manager->log() << "Received" << command->toString();
   startCommand(command);
 }
 
@@ -65,7 +65,7 @@ void Connection::writeResponse(Response *response) {
   else
     m_socket->write("failure\n");
 
-  m_manager->logger() << "Wrote response" << response->isSuccess() << response->message();
+  m_manager->log() << "Wrote response" << response->isSuccess() << response->message();
 
   QByteArray messageUtf8 = response->message();
   QString messageLength = QString::number(messageUtf8.size()) + "\n";

--- a/src/PageLoadingCommand.cpp
+++ b/src/PageLoadingCommand.cpp
@@ -14,7 +14,7 @@ PageLoadingCommand::PageLoadingCommand(Command *command, WebPageManager *manager
 }
 
 void PageLoadingCommand::start() {
-  m_manager->logger() << "Started" << m_command->toString();
+  m_manager->log() << "Started" << m_command->toString();
   connect(m_command, SIGNAL(finished(Response *)), this, SLOT(commandFinished(Response *)));
   connect(m_manager, SIGNAL(loadStarted()), this, SLOT(pageLoadingFromCommand()));
   connect(m_manager, SIGNAL(pageFinished(bool)), this, SLOT(pendingLoadFinished(bool)));
@@ -26,7 +26,7 @@ void PageLoadingCommand::pendingLoadFinished(bool success) {
   if (m_pageLoadingFromCommand) {
     m_pageLoadingFromCommand = false;
     if (m_pendingResponse) {
-      m_manager->logger() << "Page load from command finished";
+      m_manager->log() << "Page load from command finished";
       if (m_pageSuccess) {
         emit finished(m_pendingResponse);
       } else {
@@ -38,13 +38,13 @@ void PageLoadingCommand::pendingLoadFinished(bool success) {
 }
 
 void PageLoadingCommand::pageLoadingFromCommand() {
-  m_manager->logger() << m_command->toString() << "started page load";
+  m_manager->log() << m_command->toString() << "started page load";
   m_pageLoadingFromCommand = true;
 }
 
 void PageLoadingCommand::commandFinished(Response *response) {
   disconnect(m_manager, SIGNAL(loadStarted()), this, SLOT(pageLoadingFromCommand()));
-  m_manager->logger() << "Finished" << m_command->toString() << "with response" << response->toString();
+  m_manager->log() << "Finished" << m_command->toString() << "with response" << response->toString();
 
   if (m_pageLoadingFromCommand)
     m_pendingResponse = response;

--- a/src/TimeoutCommand.cpp
+++ b/src/TimeoutCommand.cpp
@@ -19,7 +19,7 @@ TimeoutCommand::TimeoutCommand(Command *command, WebPageManager *manager, QObjec
 void TimeoutCommand::start() {
   QApplication::processEvents();
   if (m_manager->isLoading()) {
-    m_manager->logger() << this->toString() << "waiting for load to finish";
+    m_manager->log() << this->toString() << "waiting for load to finish";
     connect(m_manager, SIGNAL(pageFinished(bool)), this, SLOT(pendingLoadFinished(bool)));
     startTimeout();
   } else {

--- a/src/WebPage.cpp
+++ b/src/WebPage.cpp
@@ -180,7 +180,7 @@ void WebPage::javaScriptConsoleMessage(const QString &message, int lineNumber, c
     m["line_number"] = lineNumber;
   }
   m_consoleMessages.append(m);
-  m_manager->logger() << qPrintable(fullMessage);
+  m_manager->log() << qPrintable(fullMessage);
 }
 
 void WebPage::javaScriptAlert(QWebFrame *frame, const QString &message) {
@@ -197,7 +197,7 @@ void WebPage::javaScriptAlert(QWebFrame *frame, const QString &message) {
     addModalMessage(expectedType, message, expectedMessage);
   }
 
-  m_manager->logger() << "ALERT:" << qPrintable(message);
+  m_manager->log() << "ALERT:" << qPrintable(message);
 }
 
 bool WebPage::javaScriptConfirm(QWebFrame *frame, const QString &message) {

--- a/src/WebPageManager.cpp
+++ b/src/WebPageManager.cpp
@@ -76,14 +76,14 @@ void WebPageManager::removePage(WebPage *page) {
 
 void WebPageManager::emitLoadStarted() {
   if (m_started.empty()) {
-    logger() << "Load started";
+    log() << "Load started";
     emit loadStarted();
   }
   m_started += qobject_cast<WebPage *>(sender());
 }
 
 void WebPageManager::requestCreated(QByteArray &url, QNetworkReply *reply) {
-  logger() << "Started request to" << url;
+  log() << "Started request to" << url;
   if (reply->isFinished())
     replyFinished(reply);
   else {
@@ -105,7 +105,7 @@ void WebPageManager::handleReplyFinished() {
 
 void WebPageManager::replyFinished(QNetworkReply *reply) {
   int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-  logger() << "Received" << status << "from" << reply->url().toString();
+  log() << "Received" << status << "from" << reply->url().toString();
   m_pendingReplies.removeAll(reply);
 }
 
@@ -114,7 +114,7 @@ void WebPageManager::replyDestroyed(QObject *reply) {
 }
 
 void WebPageManager::setPageStatus(bool success) {
-  logger() << "Page finished with" << success;
+  log() << "Page finished with" << success;
   m_started.remove(qobject_cast<WebPage *>(sender()));
   m_success = success && m_success;
   if (m_started.empty()) {
@@ -123,7 +123,7 @@ void WebPageManager::setPageStatus(bool success) {
 }
 
 void WebPageManager::emitPageFinished() {
-  logger() << "Load finished";
+  log() << "Load finished";
   emit pageFinished(m_success);
   m_success = true;
 }
@@ -146,7 +146,7 @@ void WebPageManager::setTimeout(int timeout) {
 
 void WebPageManager::reset() {
   foreach(QNetworkReply *reply, m_pendingReplies) {
-    logger() << "Aborting request to" << reply->url().toString();
+    log() << "Aborting request to" << reply->url().toString();
     reply->abort();
   }
   m_pendingReplies.clear();
@@ -186,7 +186,7 @@ bool WebPageManager::isLoading() const {
   return false;
 }
 
-QDebug WebPageManager::logger() const {
+QDebug WebPageManager::log() const {
   if (m_loggingEnabled) {
     return qCritical() << QTime::currentTime().toString("hh:mm:ss.zzz");
   } else {

--- a/src/WebPageManager.cpp
+++ b/src/WebPageManager.cpp
@@ -188,7 +188,7 @@ bool WebPageManager::isLoading() const {
 
 QDebug WebPageManager::logger() const {
   if (m_loggingEnabled) {
-    return qCritical();
+    return qCritical() << QTime::currentTime().toString("hh:mm:ss.zzz");
   } else {
     return QDebug(m_ignoredOutput);
   }

--- a/src/WebPageManager.h
+++ b/src/WebPageManager.h
@@ -33,7 +33,7 @@ class WebPageManager : public QObject {
     void reset();
     NetworkCookieJar *cookieJar();
     bool isLoading() const;
-    QDebug logger() const;
+    QDebug log() const;
     void enableLogging();
     void replyFinished(QNetworkReply *reply);
     NetworkAccessManager *networkAccessManager();


### PR DESCRIPTION
helps debug timing issues when log is enabled.

ps. First C++ line I've ever written not sure if there's a better way to print this but it's certainly helpful when struggling with timeout issues.

The log would look something like this:

```
QTime("22:37:13.304") Wrote response true "http://127.0.0.1:59464/"
QTime("22:37:13.304") Received "Reset()"
QTime("22:37:13.304") Started "Reset()"
QTime("22:37:13.305") Finished "Reset()" with response "Success()"
QTime("22:37:13.305") Wrote response true ""
QTime("22:37:13.305") Received "EnableLogging()"
```
