### PR TITLE
Update Travis to Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+dist: trusty
 language: ruby
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,5 @@ gemfile:
   - gemfiles/2.6.gemfile
   - gemfiles/2.5.gemfile
 before_install:
-  - gem install bundler
+  - gem install -V bundler
 install: bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - BUNDLE_JOBS=4
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
     - QMAKE=/usr/lib/x86_64-linux-gnu/qt4/bin/qmake
+    - "JRUBY_OPTS='--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -Xcext.enabled=false -J-Xss2m -Xcompile.invokedynamic=false'"
 addons:
   apt:
     sources:


### PR DESCRIPTION
The WebKit packages are no longer provided for Ubuntu Precise:

http://stackoverflow.com/questions/37201085/unable-to-locate-package-libqt5webkit5-dev

We should be able to fix this by updating to Trusty:

https://docs.travis-ci.com/user/trusty-ci-environment
