### PR TITLE
Check for Windows platform in a jruby compatible way

### DIFF
--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -49,8 +49,7 @@ module CapybaraWebkitBuilder
   end
 
   def path_to_binary
-    case RUBY_PLATFORM
-    when /mingw32/
+    if Gem.win_platform?
       "src/debug/webkit_server.exe"
     else
       "src/webkit_server"


### PR DESCRIPTION
I'm trying to get Capybara WebKit to run JRuby on Windows (I know, I know, don't judge me)

I got the C code to build, but the gem installation fails with:
`Errno::ENOENT: No such file or directory - src/webkit_server`

This is the result of checking if `RUBY_PLATFORM` is matched by the regex `mingw32`. On JRuby the platform is always reported as `java` regardless of the OS. I suggest a little tweak that should take care of that problem.
