### PR TITLE
Add gemspec requirements attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Qt Dependency and Installation Issues
 
 capybara-webkit depends on a WebKit implementation from Qt, a cross-platform
 development toolkit. You'll need to download the Qt libraries to build and
-install the gem. You can find instructions for downloading and installing QT on
+install the gem. You can find instructions for downloading and installing Qt on
 the
 [capybara-webkit wiki](https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit).
 capybara-webkit requires Qt version 4.8 or greater.

--- a/capybara-webkit.gemspec
+++ b/capybara-webkit.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9.0"
 
+  s.requirements << "Qt >= 4.8"
+
   s.add_runtime_dependency("capybara", ">= 2.3.0", "< 2.8.0")
   s.add_runtime_dependency("json")
 


### PR DESCRIPTION
This information will appear on the gem's page on rubygems.org.
http://guides.rubygems.org/specification-reference/#requirements