### PR TITLE
Handle IO::EAGAINWaitReadable error

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - bundle exec rake


### PR DESCRIPTION
This isn't a bug I can reproduce, but it has happened intermittently on our CI server while running feature tests. The error we were getting was:
```
execution expired
...
[unimportant stacktrace]
...
------------------
--- Caused by: ---
IO::EAGAINWaitReadable:
  Resource temporarily unavailable - read would block
  ./spec/support/acceptance/site_prism/avantcredit/en-US/application/apply_contract_page.rb:160:in `wait_for_contract'
```
I researched this error, *IO::EAGAINWaitReadable*, but there isn't much documentation. I did find a [stackoverflow page](http://stackoverflow.com/a/36551655/6683379) which led me to believe one of our gems wasn't handling this error.

We're using a million gems of course, but the gems primarily used in our feature tests are rspec, capybara-webkit, capybara, and siteprism. So I searched the source of each gem looking for references to *IO::EAGAINWaitReadable* or *IO::WaitReadable*, and [this line in capybara-webkit](https://github.com/thoughtbot/capybara-webkit/blob/753348ecb40b133e174225d8bd8b8ed900d2a2c2/lib/capybara/webkit/connection.rb#L43) was the only one I found.

So hypothesis: This error occurs while our feature test is waiting for an element to no longer exist. This waiting uses siteprism's *wait_until_<element_name>_invisible* method, which in turn utilizes capybara's *has_selector?* method. While waiting, this *IO::EAGAINWaitReadable* error occurs in a separate thread in capybara-webkit. As you can see rspec reports the cause of the failure, but the stack trace of the cause is lacking. I'm assuming this lacking stacktrace is normal, and is hiding the real cause of the failure.

I've run this on our test suite more than 10 times with this patch, and I haven't seen any failures that we were previously seeing. So I believe this will patch will properly fix these errors.

Please let me know if you need any other information. Thanks.