### PR TITLE
Hide CDPATH from make

### DIFF
--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -45,7 +45,7 @@ module CapybaraWebkitBuilder
   end
 
   def qmake
-    sh("#{make_bin} qmake")
+    make "qmake"
   end
 
   def path_to_binary
@@ -58,7 +58,7 @@ module CapybaraWebkitBuilder
   end
 
   def build
-    sh(make_bin) or return false
+    make or return false
 
     FileUtils.mkdir("bin") unless File.directory?("bin")
     FileUtils.cp(path_to_binary, "bin", :preserve => true)
@@ -88,5 +88,18 @@ module CapybaraWebkitBuilder
     qmake &&
     build &&
     clean
+  end
+
+  def make(target = "")
+    env_hide("CDPATH") { sh("#{make_bin} #{target}") }
+  end
+
+  def env_hide(name)
+    @stored_env ||= {}
+    @stored_env[name] = ENV.delete(name)
+
+    yield
+  ensure
+    ENV[name] = @stored_env[name]
   end
 end


### PR DESCRIPTION
The CDPATH environment variable, as used by zsh and GNU Bash, interacts
poorly with make, so hide it.

To see it interact poorly, prior to this diff:

    mkdir /tmp/src /tmp/test
    export CDPATH=/tmp
    rake build

When it attempts to `cd src`, it will go to `/tmp/src` instead of the
correct place in this tree.

Examples of this bug have appeared in #56, #572, and #852.

Closes #947.