### PR TITLE
Get Travis build running again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+dist: trusty
 language: ruby
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
     - BUNDLE_JOBS=4
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-    - QMAKE=/usr/lib/x86_64-linux-gnu/qt4/bin/qmake
+    - QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
     - JAVA_OPTS=-Djava.security.egd=file:/dev/urandom
 addons:
   apt:
@@ -26,13 +26,12 @@ matrix:
   include:
     - rvm: 1.9.3
       gemfile: gemfiles/2.6.gemfile
-      env: QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
+      env: QMAKE=/usr/lib/x86_64-linux-gnu/qt4/bin/qmake
     - rvm: 1.9.3
       gemfile: gemfiles/2.5.gemfile
-      env: QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
-    - rvm: 2.2
+      env: QMAKE=/usr/lib/x86_64-linux-gnu/qt4/bin/qmake
+    - rvm: 2.3.1
       gemfile: gemfiles/master.gemfile
-      env: QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
   allow_failures:
     - gemfile: gemfiles/master.gemfile
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - BUNDLE_JOBS=4
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
     - QMAKE=/usr/lib/x86_64-linux-gnu/qt4/bin/qmake
+    - JAVA_OPTS=-Djava.security.egd=file:/dev/urandom
 addons:
   apt:
     sources:

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 gem "mime-types", "< 3.0", platforms: [:ruby_19, :jruby_19]
+gem "json", "< 2.0", :platforms=>[:ruby_19, :jruby_19]

--- a/gemfiles/2.6.gemfile
+++ b/gemfiles/2.6.gemfile
@@ -3,6 +3,8 @@
 source "https://rubygems.org"
 
 gem "mime-types", "< 3.0", :platforms=>[:ruby_19, :jruby_19]
+gem "json", "< 2.0", :platforms=>[:ruby_19, :jruby_19]
+
 gem "capybara", "~> 2.6.0"
 
 gemspec :path=>"../"

--- a/gemfiles/2.7.gemfile
+++ b/gemfiles/2.7.gemfile
@@ -3,6 +3,8 @@
 source "https://rubygems.org"
 
 gem "mime-types", "< 3.0", :platforms=>[:ruby_19, :jruby_19]
+gem "json", "< 2.0", :platforms=>[:ruby_19, :jruby_19]
+
 gem "capybara", "~> 2.7.0"
 
 gemspec :path=>"../"

--- a/gemfiles/master.gemfile
+++ b/gemfiles/master.gemfile
@@ -3,6 +3,8 @@
 source "https://rubygems.org"
 
 gem "mime-types", "< 3.0", :platforms=>[:ruby_19, :jruby_19]
+gem "json", "< 2.0", :platforms=>[:ruby_19, :jruby_19]
+
 gem "capybara", :github=>"jnicklas/capybara"
 
 gemspec :path=>"../"


### PR DESCRIPTION
This gets the travis build running again.  JRuby was failing due to a lack of entropy in /dev/random.  The first commit here swaps that to /dev/urandom which should be fine since running CI for capybara-webkit isn't encryption/security sensitive.  The other commits are self explanatory and make a few more changes to get things running.  Note: the JRuby tests do have 2 failures, hopefully someone has a clue about whats causing them.