### PR TITLE
Using updated failure_message methods in matcher

### DIFF
--- a/lib/capybara/webkit/matchers.rb
+++ b/lib/capybara/webkit/matchers.rb
@@ -7,11 +7,11 @@ module Capybara
           actual.error_messages.any?
         end
 
-        failure_message_for_should do |actual|
+        failure_message do |actual|
           "Expected Javascript errors, but there were none."
         end
-        
-        failure_message_for_should_not do |actual|
+
+        failure_message_when_negated do |actual|
           actual = resolve(actual)
           "Expected no Javascript errors, got:\n#{error_messages_for(actual)}"
         end


### PR DESCRIPTION
When used with RSpec 3.5.2, lines 10 and 14 throw deprecation errors. I replaced the failure_message_for_should and failure_message_for_should_not calls as instructed in the deprecation
message.
