### PR TITLE
Allow JavaScript errors to be raised as exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Capybara::Webkit.configure do |config|
     user: "proxy",
     pass: "secret"
   )
+
+  # Raise JavaScript errors as exceptions when visiting a page
+  config.raise_javascript_errors = true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Capybara::Webkit.configure do |config|
     pass: "secret"
   )
 
-  # Raise JavaScript errors as exceptions when visiting a page
+  # Raise JavaScript errors as exceptions
   config.raise_javascript_errors = true
 end
 ```

--- a/lib/capybara/webkit/browser.rb
+++ b/lib/capybara/webkit/browser.rb
@@ -101,8 +101,8 @@ module Capybara::Webkit
       command("SetSkipImageLoading", skip_image_loading)
     end
 
-    def set_raise_javascript_errors(isEnabled)
-      @raise_javascript_errors = isEnabled
+    def set_raise_javascript_errors(is_enabled)
+      @raise_javascript_errors = is_enabled
     end
 
     def raise_javascript_errors?

--- a/lib/capybara/webkit/browser.rb
+++ b/lib/capybara/webkit/browser.rb
@@ -5,6 +5,7 @@ module Capybara::Webkit
   class Browser
     def initialize(connection)
       @connection = connection
+      apply_defaults
     end
 
     def authenticate(username, password)
@@ -36,6 +37,7 @@ module Capybara::Webkit
     end
 
     def reset!
+      apply_defaults
       command("Reset")
     end
 
@@ -97,6 +99,14 @@ module Capybara::Webkit
 
     def set_skip_image_loading(skip_image_loading)
       command("SetSkipImageLoading", skip_image_loading)
+    end
+
+    def set_raise_javascript_errors(isEnabled)
+      @raise_javascript_errors = isEnabled
+    end
+
+    def raise_javascript_errors?
+      @raise_javascript_errors
     end
 
     def window_focus(selector)
@@ -209,7 +219,9 @@ module Capybara::Webkit
         @connection.print arg.to_s
       end
       check
-      read_response
+      response = read_response
+      check_javascript_errors(name)
+      response
     rescue SystemCallError => exception
       @connection.restart
       raise(Capybara::Webkit::CrashError, <<-MESSAGE.strip)
@@ -295,6 +307,10 @@ https://github.com/thoughtbot/capybara-webkit/wiki/Reporting-Crashes
 
     private
 
+    def apply_defaults
+      @raise_javascript_errors = false
+    end
+
     def check
       result = @connection.gets
       result.strip! if result
@@ -306,6 +322,14 @@ https://github.com/thoughtbot/capybara-webkit/wiki/Reporting-Crashes
       end
 
       result
+    end
+
+    def check_javascript_errors(command_name)
+      return if command_name == "ConsoleMessages"
+
+      if raise_javascript_errors? && error_messages.any?
+        raise JavaScriptError, error_messages
+      end
     end
 
     def read_response

--- a/lib/capybara/webkit/configuration.rb
+++ b/lib/capybara/webkit/configuration.rb
@@ -30,6 +30,7 @@ module Capybara
       attr_accessor :stderr
       attr_accessor :timeout
       attr_writer :skip_image_loading
+      attr_accessor :raise_javascript_errors
 
       def initialize
         @allowed_urls = []
@@ -41,6 +42,7 @@ module Capybara
         @skip_image_loading = false
         @stderr = $stderr
         @timeout = -1
+        @raise_javascript_errors = false
       end
 
       def allow_url(url)
@@ -93,7 +95,8 @@ module Capybara
           proxy: proxy,
           skip_image_loading: skip_image_loading?,
           stderr: stderr,
-          timeout: timeout
+          timeout: timeout,
+          raise_javascript_errors: raise_javascript_errors,
         }
       end
     end

--- a/lib/capybara/webkit/configuration.rb
+++ b/lib/capybara/webkit/configuration.rb
@@ -96,7 +96,7 @@ module Capybara
           skip_image_loading: skip_image_loading?,
           stderr: stderr,
           timeout: timeout,
-          raise_javascript_errors: raise_javascript_errors
+          raise_javascript_errors: raise_javascript_errors,
         }
       end
     end

--- a/lib/capybara/webkit/configuration.rb
+++ b/lib/capybara/webkit/configuration.rb
@@ -96,7 +96,7 @@ module Capybara
           skip_image_loading: skip_image_loading?,
           stderr: stderr,
           timeout: timeout,
-          raise_javascript_errors: raise_javascript_errors,
+          raise_javascript_errors: raise_javascript_errors
         }
       end
     end

--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -398,8 +398,8 @@ module Capybara::Webkit
         @browser.timeout = @options[:timeout]
       end
 
-      if @options[:raise_javascript_errors]
-        @browser.set_raise_javascript_errors(true)
+      if @options.has_key? :raise_javascript_errors
+        @browser.set_raise_javascript_errors(@options[:raise_javascript_errors])
       end
 
       Array(@options[:allowed_urls]).each { |url| @browser.allow_url(url) }

--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -49,8 +49,8 @@ module Capybara::Webkit
     def visit(path)
       visit_response = @browser.visit(path)
 
-      if raise_javascript_errors? && has_error_messages?
-        raise JavaScriptError.new(error_messages)
+      if raise_javascript_errors? && error_messages.any?
+        raise JavaScriptError, error_messages
       end
 
       visit_response
@@ -430,10 +430,6 @@ module Capybara::Webkit
 
     def raise_javascript_errors?
       @options[:raise_javascript_errors]
-    end
-
-    def has_error_messages?
-      !error_messages.empty?
     end
   end
 end

--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -47,7 +47,13 @@ module Capybara::Webkit
     end
 
     def visit(path)
-      @browser.visit(path)
+      visit_response = @browser.visit(path)
+
+      if raise_javascript_errors? && has_error_messages?
+        raise JavaScriptError.new(error_messages)
+      end
+
+      visit_response
     end
 
     def find_xpath(xpath)
@@ -420,6 +426,14 @@ module Capybara::Webkit
           arg.to_json
         end
       end
+    end
+
+    def raise_javascript_errors?
+      @options[:raise_javascript_errors]
+    end
+
+    def has_error_messages?
+      !error_messages.empty?
     end
   end
 end

--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -47,13 +47,7 @@ module Capybara::Webkit
     end
 
     def visit(path)
-      visit_response = @browser.visit(path)
-
-      if raise_javascript_errors? && error_messages.any?
-        raise JavaScriptError, error_messages
-      end
-
-      visit_response
+      @browser.visit(path)
     end
 
     def find_xpath(xpath)
@@ -404,6 +398,10 @@ module Capybara::Webkit
         @browser.timeout = @options[:timeout]
       end
 
+      if @options[:raise_javascript_errors]
+        @browser.set_raise_javascript_errors(true)
+      end
+
       Array(@options[:allowed_urls]).each { |url| @browser.allow_url(url) }
       Array(@options[:blocked_urls]).each { |url| @browser.block_url(url) }
     end
@@ -426,10 +424,6 @@ module Capybara::Webkit
           arg.to_json
         end
       end
-    end
-
-    def raise_javascript_errors?
-      @options[:raise_javascript_errors]
     end
   end
 end

--- a/lib/capybara/webkit/errors.rb
+++ b/lib/capybara/webkit/errors.rb
@@ -44,4 +44,13 @@ module Capybara::Webkit
       Capybara::Webkit.const_get @class_name
     end
   end
+
+  class JavaScriptError < StandardError
+    def initialize(errors)
+      @javascript_errors = errors
+      super(errors.join(","))
+    end
+
+    attr_reader :javascript_errors
+  end
 end

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -43,4 +43,20 @@ describe Capybara::Webkit::Browser do
       end
     end
   end
+
+  describe '#reset!' do
+    it 'resets to the default state' do
+      connection = double("connection", puts: nil, print: nil)
+      allow(connection).to receive(:gets).and_return("ok\n", "{}\n")
+
+      browser = Capybara::Webkit::Browser.new(connection)
+      browser.set_raise_javascript_errors(true)
+
+      expect(browser.raise_javascript_errors?).to be true
+
+      browser.reset!
+
+      expect(browser.raise_javascript_errors?).to be false
+    end
+  end
 end

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -44,8 +44,8 @@ describe Capybara::Webkit::Browser do
     end
   end
 
-  describe '#reset!' do
-    it 'resets to the default state' do
+  describe "#reset!" do
+    it "resets to the default state" do
       connection = double("connection", puts: nil, print: nil)
       allow(connection).to receive(:gets).and_return("ok\n", "{}\n")
 

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -3467,10 +3467,10 @@ CACHE MANIFEST
       expected_error = Capybara::Webkit::JavaScriptError
       expected_message = "ReferenceError: Can't find variable: undefinedFunc"
 
-      expect { visit('/') }.to raise_error(expected_error) do |error|
+      expect { visit("/") }.to raise_error(expected_error) do |error|
         expect(error.javascript_errors.first[:message]).to eq expected_message
       end
-      expect { driver.find_css('h1') }.to raise_error(expected_error)
+      expect { driver.find_css("h1") }.to raise_error(expected_error)
     end
 
     it "does not raise an exception when fetching the error messages" do
@@ -3482,7 +3482,7 @@ CACHE MANIFEST
     end
 
     it "does not raise errors as an exception by default" do
-      expect { visit('/') }.to_not raise_error
+      expect { visit("/") }.to_not raise_error
       expect(driver.error_messages).to_not be_empty
     end
   end

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -3467,8 +3467,8 @@ CACHE MANIFEST
       expected_error = Capybara::Webkit::JavaScriptError
 
       expect { visit('/') }.to raise_error(expected_error) do |error|
-        expect(error.javascript_errors.first.fetch(:message)).
-          to eq "ReferenceError: Can't find variable: undefinedFunc"
+        expect(error.javascript_errors.first.fetch(:message))
+          .to eq "ReferenceError: Can't find variable: undefinedFunc"
       end
     end
 

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -3465,11 +3465,20 @@ CACHE MANIFEST
       end
 
       expected_error = Capybara::Webkit::JavaScriptError
+      expected_message = "ReferenceError: Can't find variable: undefinedFunc"
 
       expect { visit('/') }.to raise_error(expected_error) do |error|
-        expect(error.javascript_errors.first.fetch(:message))
-          .to eq "ReferenceError: Can't find variable: undefinedFunc"
+        expect(error.javascript_errors.first[:message]).to eq expected_message
       end
+      expect { driver.find_css('h1') }.to raise_error(expected_error)
+    end
+
+    it "does not raise an exception when fetching the error messages" do
+      configure do |config|
+        config.raise_javascript_errors = true
+      end
+
+      expect { driver.error_messages }.to_not raise_error
     end
 
     it "does not raise errors as an exception by default" do

--- a/spec/support/app_runner.rb
+++ b/spec/support/app_runner.rb
@@ -21,6 +21,7 @@ module AppRunner
     end
 
     self.browser = $webkit_browser
+    self.browser.reset!
 
     self.configuration = Capybara::Webkit::Configuration.new
   end


### PR DESCRIPTION
When configured, upon taking any action: 

- The driver checks that no JavaScript errors are present on the page.
- If JavaScript errors are present then an exception is raised. 
- The exception includes the JavaScript error messages:

```
#<Capybara::Webkit::JavaScriptError: {:line_number=>5, :message=>"ReferenceError: Can't find variable: undefinedFunc", :source=>"http://127.0.0.1:56520/"}>
```

---

### Motivation

On a project using `capybara-webkit` the test-suite passed despite a critical JavaScript minification bug. Because the specs didn't defensively assert that `error_messages` are empty on each navigation, the bug wasn't caught.

I think this option acts as a good safeguard — a strict mode if you will — and will also aid debugging during the TDD cycle. If a failing scenario (now implemented) is still failing, this could speed up figuring out that the failure is due to a different reason than you thought it was.

This feature is inspired by Poltergeist which has an option to [raise JS errors as exceptions](https://github.com/teampoltergeist/poltergeist#customization).

---

### Questions

- This could also check & raise JavaScript errors on other interactions, like clicking a button. Would this be helpful too? [Update: This PR has now been updated so all interactions perform the check]