### PR TITLE
Build the webkit server executable in parallel

### DIFF
--- a/lib/capybara_webkit_builder.rb
+++ b/lib/capybara_webkit_builder.rb
@@ -1,3 +1,4 @@
+require 'etc'
 require "fileutils"
 require "rbconfig"
 require "shellwords"
@@ -91,7 +92,8 @@ module CapybaraWebkitBuilder
   end
 
   def make(target = "")
-    env_hide("CDPATH") { sh("#{make_bin} #{target}") }
+    job_count = Etc.respond_to?(:nprocessors) ? Etc.nprocessors : 1
+    env_hide('CDPATH') { sh("#{make_bin} #{target} --jobs=#{job_count}") }
   end
 
   def env_hide(name)


### PR DESCRIPTION
During the gem installation there is a message that says `"Building native extensions.  This could take a while..."`. And it takes a while.

This PR should make it take a bit less for people with more cores and Ruby 2+.