### PR TITLE
Capybara 2.13 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.swp
 bin/webkit_server*
 test/testwebkitserver
+test/moc_predefs.h
+test/target_wrapper.sh
 *.swo
 *~
 *.o

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
       gemfile: gemfiles/2.7.gemfile
       env: QMAKE=/usr/lib/x86_64-linux-gnu/qt4/bin/qmake
     - rvm: 1.9.3
-      gemfile: gemfiles/2.12.gemfile
+      gemfile: gemfiles/2.13.gemfile
       env: QMAKE=/usr/lib/x86_64-linux-gnu/qt4/bin/qmake
     - rvm: 2.3.3
       gemfile: gemfiles/master.gemfile
@@ -36,7 +36,7 @@ matrix:
     - gemfile: gemfiles/master.gemfile
 gemfile:
   - gemfiles/2.7.gemfile
-  - gemfiles/2.12.gemfile
+  - gemfiles/2.13.gemfile
 before_install:
   - gem install bundler
 install: bundle

--- a/Appraisals
+++ b/Appraisals
@@ -5,8 +5,8 @@ appraise "2.7" do
   gem 'nokogiri', '< 1.7.0', :platforms=>[:ruby_19, :jruby_19] # 1.7.0 requires ruby 2.1+
 end
 
-appraise "2.12" do
-  gem "capybara", "~> 2.12.0"
+appraise "2.13" do
+  gem "capybara", "~> 2.13.0"
   gem 'addressable', '< 2.5.0', :platforms=>[:ruby_19, :jruby_19] # 2.5 requires public_suffix which requires ruby 2.0
   gem 'nokogiri', '< 1.7.0', :platforms=>[:ruby_19, :jruby_19] # 1.7.0 requires ruby 2.1+
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     capybara-webkit (1.13.0)
-      capybara (>= 2.3.0, < 2.13.0)
+      capybara (>= 2.3.0, < 2.14.0)
       json
 
 GEM
@@ -13,7 +13,7 @@ GEM
     appraisal (0.4.1)
       bundler
       rake
-    capybara (2.12.0)
+    capybara (2.13.0)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -21,7 +21,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     diff-lcs (1.3)
-    ffi (1.9.17-java)
+    ffi (1.9.18-java)
     json (1.8.6)
     json (1.8.6-java)
     launchy (2.4.3)
@@ -30,12 +30,12 @@ GEM
       addressable (~> 2.3)
       spoon (~> 0.0.1)
     mime-types (2.99.3)
-    mini_magick (4.6.0)
+    mini_magick (4.6.1)
     mini_portile2 (2.1.0)
-    nokogiri (1.7.0.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
-    nokogiri (1.7.0.1-java)
-    nokogiri (1.7.0.1-x86-mingw32)
+    nokogiri (1.7.1-java)
+    nokogiri (1.7.1-x86-mingw32)
       mini_portile2 (~> 2.1.0)
     public_suffix (2.0.5)
     rack (1.6.5)
@@ -63,7 +63,7 @@ GEM
       tilt (>= 1.3, < 3)
     spoon (0.0.6)
       ffi
-    tilt (2.0.6)
+    tilt (2.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -84,4 +84,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   1.14.3
+   1.14.5

--- a/capybara-webkit.gemspec
+++ b/capybara-webkit.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.requirements << "Qt >= 4.8"
 
-  s.add_runtime_dependency("capybara", ">= 2.3.0", "< 2.13.0")
+  s.add_runtime_dependency("capybara", ">= 2.3.0", "< 2.14.0")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("rspec", "~> 3.5")

--- a/gemfiles/2.13.gemfile
+++ b/gemfiles/2.13.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "mime-types", "< 3.0", :platforms=>[:ruby_19, :jruby_19]
 gem "json", "< 2.0", :platforms=>[:ruby_19, :jruby_19]
-gem "capybara", "~> 2.12.0"
+gem "capybara", "~> 2.13.0"
 gem "addressable", "< 2.5.0", :platforms=>[:ruby_19, :jruby_19]
 gem "nokogiri", "< 1.7.0", :platforms=>[:ruby_19, :jruby_19]
 

--- a/lib/capybara/webkit/browser.rb
+++ b/lib/capybara/webkit/browser.rb
@@ -83,7 +83,7 @@ module Capybara::Webkit
 
     def frame_focus(selector=nil)
       if selector.respond_to?(:base)
-        selector.base.invoke('focus')
+        selector.base.invoke("focus_frame")
       elsif selector.is_a? Fixnum
         command("FrameFocus", "", selector.to_s)
       elsif selector

--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -420,7 +420,7 @@ module Capybara::Webkit
     def encode_args(args)
       args.map do |arg|
         if arg.is_a?(Capybara::Webkit::Node)
-          { 'element-581e-422e-8be1-884c4e116226' => arg.native }.to_json
+          { "element-581e-422e-8be1-884c4e116226" => arg.native }.to_json
         else
           arg.to_json
         end
@@ -432,10 +432,10 @@ module Capybara::Webkit
       when Array
         result.map { |r| decode_result(r) }
       when Hash
-        if element_ref = result['element-581e-422e-8be1-884c4e116226']
+        if element_ref = result["element-581e-422e-8be1-884c4e116226"]
           Capybara::Webkit::Node.new(self, element_ref, @browser)
         else
-          result.each { |k,v| result[k] = decode_result(v) }
+          result.each { |k, v| result[k] = decode_result(v) }
         end
       else
         result

--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -87,7 +87,8 @@ module Capybara::Webkit
     end
 
     def evaluate_script(script, *args)
-      @browser.evaluate_script(script, *encode_args(args))
+      result = @browser.evaluate_script(script, *encode_args(args))
+      decode_result(result)
     end
 
     def console_messages
@@ -419,10 +420,25 @@ module Capybara::Webkit
     def encode_args(args)
       args.map do |arg|
         if arg.is_a?(Capybara::Webkit::Node)
-          { ELEMENT: arg.native }.to_json
+          { 'element-581e-422e-8be1-884c4e116226' => arg.native }.to_json
         else
           arg.to_json
         end
+      end
+    end
+
+    def decode_result(result)
+      case result
+      when Array
+        result.map { |r| decode_result(r) }
+      when Hash
+        if element_ref = result['element-581e-422e-8be1-884c4e116226']
+          Capybara::Webkit::Node.new(self, element_ref, @browser)
+        else
+          result.each { |k,v| result[k] = decode_result(v) }
+        end
+      else
+        result
       end
     end
   end

--- a/lib/capybara/webkit/node.rb
+++ b/lib/capybara/webkit/node.rb
@@ -48,20 +48,9 @@ module Capybara::Webkit
     end
 
     def send_keys(*keys)
-      invoke("sendKeys", keys.map { |key|
-        case key
-        when :space
-          " "
-        when :enter
-          "\r"
-        when :backspace
-          "\b"
-        when String
-          key.to_s
-        else
-          raise Capybara::NotSupportedByDriverError.new, "Unrecognized key(s) in #{key}"
-        end
-      }.join)
+      # Currently unsupported keys specified by Capybara
+      # :separator
+      invoke("sendKeys", convert_to_named_keys(keys).to_json)
     end
 
     def select_option
@@ -171,6 +160,46 @@ module Capybara::Webkit
 
     def ==(other)
       invoke("equals", other.native) == "true"
+    end
+
+    private
+
+    def convert_to_named_keys(key)
+      if key.is_a? Array
+        key.map {|k| convert_to_named_keys(k)}
+      else
+        case key
+        when :cancel, :help, :backspace, :tab, :clear, :return, :enter, :insert, :delete, :pause, :escape,
+             :space, :end, :home, :left, :up, :right, :down, :semicolon,
+             :f1, :f2, :f3, :f4, :f5, :f6, :f7, :f8, :f9, :f10, :f11, :f12,
+             :shift, :control, :alt, :meta
+          { "key" =>  key.to_s.capitalize }
+        when :equals
+          { "key" => "Equal" }
+        when :page_up
+          { "key" => "PageUp" }
+        when :page_down
+          { "key" => "PageDown" }
+        when :numpad0, :numpad1, :numpad2, :numpad3, :numpad4, :numpad5, :numpad6, :numpad7, :numpad9, :numpad9
+          { "key" => key[-1], "modifier" => 'Keypad' }
+        when :multiply
+          { "key" => "Asterisk", "modifier" => 'Keypad' }
+        when :divide
+          { "key" => "Slash", "modifier" => 'Keypad' }
+        when :add
+          { "key" => "Plus", "modifier" => 'Keypad' }
+        when :subtract
+          { "key" => "Minus", "modifier" => 'Keypad' }
+        when :decimal
+          {"key" => "Period", "modifier" => 'Keypad'}
+        when :command
+          { "key" => "Meta" }
+        when String
+          key.to_s
+        else
+          raise Capybara::NotSupportedByDriverError.new
+        end
+      end
     end
   end
 end

--- a/lib/capybara/webkit/node.rb
+++ b/lib/capybara/webkit/node.rb
@@ -166,32 +166,33 @@ module Capybara::Webkit
 
     def convert_to_named_keys(key)
       if key.is_a? Array
-        key.map {|k| convert_to_named_keys(k)}
+        key.map { |k| convert_to_named_keys(k)}
       else
         case key
         when :cancel, :help, :backspace, :tab, :clear, :return, :enter, :insert, :delete, :pause, :escape,
              :space, :end, :home, :left, :up, :right, :down, :semicolon,
              :f1, :f2, :f3, :f4, :f5, :f6, :f7, :f8, :f9, :f10, :f11, :f12,
              :shift, :control, :alt, :meta
-          { "key" =>  key.to_s.capitalize }
+          { "key" => key.to_s.capitalize }
         when :equals
           { "key" => "Equal" }
         when :page_up
           { "key" => "PageUp" }
         when :page_down
           { "key" => "PageDown" }
-        when :numpad0, :numpad1, :numpad2, :numpad3, :numpad4, :numpad5, :numpad6, :numpad7, :numpad9, :numpad9
-          { "key" => key[-1], "modifier" => 'Keypad' }
+        when :numpad0, :numpad1, :numpad2, :numpad3, :numpad4,
+             :numpad5, :numpad6, :numpad7, :numpad9, :numpad9
+          { "key" => key[-1], "modifier" => "keypad" }
         when :multiply
-          { "key" => "Asterisk", "modifier" => 'Keypad' }
+          { "key" => "Asterisk", "modifier" => "keypad" }
         when :divide
-          { "key" => "Slash", "modifier" => 'Keypad' }
+          { "key" => "Slash", "modifier" => "keypad" }
         when :add
-          { "key" => "Plus", "modifier" => 'Keypad' }
+          { "key" => "Plus", "modifier" => "keypad" }
         when :subtract
-          { "key" => "Minus", "modifier" => 'Keypad' }
+          { "key" => "Minus", "modifier" => "keypad" }
         when :decimal
-          {"key" => "Period", "modifier" => 'Keypad'}
+          { "key" => "Period", "modifier" => "keypad" }
         when :command
           { "key" => "Meta" }
         when String

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -524,17 +524,17 @@ describe Capybara::Webkit::Driver do
 
     it "evaluates Javascript and returns an element" do
       result = driver.evaluate_script(%<document.getElementById('greeting')>)
-      expect(result).to eq driver.find_css('#greeting').first
+      expect(result).to eq driver.find_css("#greeting").first
     end
 
     it "evaluates Javascript and returns a structure containing elements" do
       result = driver.evaluate_script(%<({ 'a': document.getElementById('greeting'), 'b': { 'c': document.querySelectorAll('#greeting, #checktest') } })>)
-      expect(result).to eq({
-        'a' => driver.find_css('#greeting').first,
-        'b' => {
-          'c' => driver.find_css('#greeting, #checktest')
-        }
-      })
+      expect(result).to eq(
+        "a" => driver.find_css("#greeting").first,
+        "b" => {
+          "c" => driver.find_css("#greeting, #checktest")
+        },
+      )
     end
 
     it "evaluates Javascript and returns null" do
@@ -1379,7 +1379,8 @@ describe Capybara::Webkit::Driver do
       it "releases modifiers correctly" do
         input = driver.find_xpath("//input").first
         input.send_keys("a", [:shift, :left], "a")
-        expect(driver.find_css("#key_events").first.text).to eq "d:65 u:65 d:16 d:37 u:37 u:16 d:65 u:65"
+        event_text = driver.find_css("#key_events").first.text
+        expect(event_text).to eq "d:65 u:65 d:16 d:37 u:37 u:16 d:65 u:65"
       end
     end
 

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -1273,6 +1273,17 @@ describe Capybara::Webkit::Driver do
             <input type="radio" id="only-radio" value="1"/>
             <button type="reset">Reset Form</button>
           </form>
+          <div id="key_events"></div>
+          <script>
+            var form = document.getElementsByTagName('form')[0];
+            var output = document.getElementById('key_events');
+            form.addEventListener('keydown', function(e){
+              output.innerHTML = output.innerHTML + " d:" + (e.key || e.which);
+            });
+            form.addEventListener('keyup', function(e){
+              output.innerHTML = output.innerHTML + " u:" + (e.key || e.which);
+            });
+          </script>
         </body></html>
       HTML
     end
@@ -1340,6 +1351,20 @@ describe Capybara::Webkit::Driver do
         expect(input.value).to eq "dog"
         input.send_keys(*[:backspace])
         expect(input.value).to eq "do"
+      end
+
+      it "should support :modifiers" do
+        input = driver.find_xpath("//input").first
+        input.send_keys("abc", [:shift, :left], "def")
+        expect(input.value).to eq "abdef"
+        input.send_keys([:control, "a"], [:shift, "upper"])
+        expect(input.value).to eq "UPPER"
+      end
+
+      it "releases modifiers correctly" do
+        input = driver.find_xpath("//input").first
+        input.send_keys("a", [:shift, :left], "a")
+        expect(driver.find_css("#key_events").first.text).to eq "d:65 u:65 d:16 d:37 u:37 u:16 d:65 u:65"
       end
     end
 

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -522,6 +522,21 @@ describe Capybara::Webkit::Driver do
       expect(result).to eq 1.5
     end
 
+    it "evaluates Javascript and returns an element" do
+      result = driver.evaluate_script(%<document.getElementById('greeting')>)
+      expect(result).to eq driver.find_css('#greeting').first
+    end
+
+    it "evaluates Javascript and returns a structure containing elements" do
+      result = driver.evaluate_script(%<({ 'a': document.getElementById('greeting'), 'b': { 'c': document.querySelectorAll('#greeting, #checktest') } })>)
+      expect(result).to eq({
+        'a' => driver.find_css('#greeting').first,
+        'b' => {
+          'c' => driver.find_css('#greeting, #checktest')
+        }
+      })
+    end
+
     it "evaluates Javascript and returns null" do
       result = driver.evaluate_script(%<(function () {})()>)
       expect(result).to eq nil

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -325,6 +325,16 @@ describe Capybara::Session do
         end
       end
     end
+
+    it "can swap to the same frame multiple times" do
+      subject.visit("/")
+      subject.within_frame("a_frame") do
+        expect(subject).to have_content("Page A")
+      end
+      subject.within_frame("a_frame") do
+        expect(subject).to have_content("Page A")
+      end
+    end
   end
 
   context 'click tests' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,15 +52,13 @@ RSpec.configure do |c|
   # Accessing unattached nodes is allowed when reload is disabled - Legacy behavior
   # Node#send_keys does not support modifiers and only supports a subset of special keys
   c.filter_run_excluding :full_description => lambda { |description, metadata|
-    (description !~ /Capybara::Session webkit node #send_keys should send a string of keys to an element/) && (
-        description =~ /Capybara::Session webkit node #send_keys/ ||
-        description =~ /Capybara::Session webkit node #reload without automatic reload should not automatically reload/ ||
-      if Gem::Version.new(Capybara::VERSION) < Gem::Version.new("2.12.0")
-        description =~ /Capybara::Session webkit Capybara::Window\s*#(size|resize_to|maximize|close.*no_such_window_error|send_keys)/ ||
-        description =~ /Capybara::Session webkit node\s*#set should allow me to change the contents of a contenteditable elements child/
-      else
-        description =~ /Capybara::Session webkit Capybara::Window\s*#close.*no_such_window_error/
-      end
+    (description =~ /Capybara::Session webkit node #reload without automatic reload should not automatically reload/ ||
+     if Gem::Version.new(Capybara::VERSION) < Gem::Version.new("2.12.0")
+       description =~ /Capybara::Session webkit Capybara::Window\s*#(size|resize_to|maximize|close.*no_such_window_error)/ ||
+       description =~ /Capybara::Session webkit node\s*#set should allow me to change the contents of a contenteditable elements child/
+     else
+       description =~ /Capybara::Session webkit Capybara::Window\s*#close.*no_such_window_error/
+     end
     )
   }
 end

--- a/src/Evaluate.cpp
+++ b/src/Evaluate.cpp
@@ -18,12 +18,14 @@ void Evaluate::start() {
   QString eval_script = QString("(function(){"
                            "   for(var i=0; i<arguments.length; i++) {"
                            "     arguments[i] = JSON.parse(arguments[i]);"
-                           "     if (arguments[i]['ELEMENT']) {"
-                           "       arguments[i] = Capybara.getNode(arguments[i]['ELEMENT']);"
+                           "     var elem_id;"
+                           "     if (elem_id = arguments[i]['element-581e-422e-8be1-884c4e116226']) {"
+                           "       arguments[i] = Capybara.getNode(elem_id);"
                            "     };"
                            "   };"
-                           "   return eval(\"%1\");"
-                           "   }).apply(null, %2)").arg(script.replace("\"","\\\"").remove("\n"), jsonArgs);
+                           "   var _result = eval(\"%1\");"
+                           "   return Capybara.wrapResult(_result);"
+                           " }).apply(null, %2)").arg(script.replace("\"","\\\"").remove("\n"), jsonArgs);
   QObject invocation_stub;
   invocation_stub.setProperty("allowUnattached", false);
   page()->currentFrame()->addToJavaScriptWindowObject("CapybaraInvocation", &invocation_stub);

--- a/src/Execute.cpp
+++ b/src/Execute.cpp
@@ -16,8 +16,9 @@ void Execute::start() {
   QString script = QString("(function(){"
                            "   for(var i=0; i<arguments.length; i++) {"
                            "     arguments[i] = JSON.parse(arguments[i]);"
-                           "     if (arguments[i]['ELEMENT']) {"
-                           "       arguments[i] = Capybara.getNode(arguments[i]['ELEMENT']);"
+                           "     var elem_id;"
+                           "     if (elem_id = arguments[i]['element-581e-422e-8be1-884c4e116226']) {"
+                           "       arguments[i] = Capybara.getNode(elem_id);"
                            "     };"
                            "   };"
                            "   %1 }).apply(null, %2); 'success'").arg(arguments()[0], jsonArgs);

--- a/src/JavascriptInvocation.h
+++ b/src/JavascriptInvocation.h
@@ -13,6 +13,7 @@ class JavascriptInvocation : public QObject {
   Q_PROPERTY(bool allowUnattached READ allowUnattached)
   Q_PROPERTY(QStringList arguments READ arguments)
   Q_PROPERTY(QVariant error READ getError WRITE setError)
+  Q_PROPERTY(Qt::Key key_enum)
 
   public:
     JavascriptInvocation(const QString &functionName, bool allowUnattached, const QStringList &arguments, WebPage *page, QObject *parent = 0);
@@ -26,6 +27,9 @@ class JavascriptInvocation : public QObject {
     Q_INVOKABLE QVariantMap clickPosition(QWebElement element, int left, int top, int width, int height);
     Q_INVOKABLE void hover(int absoluteX, int absoluteY);
     Q_INVOKABLE void keypress(QChar);
+    Q_INVOKABLE void namedKeydown(QString keyName);
+    Q_INVOKABLE void namedKeyup(QString keyName);
+    Q_INVOKABLE void namedKeypress(QString keyName, QString modifiers);
     Q_INVOKABLE const QString render(void);
     QVariant getError();
     void setError(QVariant error);
@@ -39,5 +43,8 @@ class JavascriptInvocation : public QObject {
     QVariant m_error;
     void hover(const QPoint &);
     int keyCodeFor(const QChar &);
+    int keyCodeForName(const QString &);
+    Qt::Key key_enum;
+    Qt::KeyboardModifiers m_currentModifiers;
 };
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -11,7 +11,7 @@ void Node::start() {
   QString functionName = functionArguments.takeFirst();
   QString allowUnattached = functionArguments.takeFirst();
   InvocationResult result = page()->invokeCapybaraFunction(functionName, allowUnattached == "true", functionArguments);
-  if (functionName == "focus") {
+  if (functionName == "focus_frame") {
     page()->setCurrentFrameParent(page()->currentFrame()->parentFrame());
   }
   finish(&result);

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -357,6 +357,14 @@ Capybara = {
     this.getNode(index).focus();
   },
 
+  focus_frame: function(index) {
+    var elem = this.getNode(index);
+    if (elem === document.activeElement) {
+      elem.blur();
+    }
+    elem.focus();
+  },
+
   selectOption: function(index) {
     var optionNode = this.getNode(index);
     var selectNode = optionNode.parentNode;

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -314,7 +314,7 @@ Capybara = {
         CapybaraInvocation.namedKeyup(mods.pop().key);
       }
     } else {
-      key = keys.key
+      key = keys.key;
       if (["Shift", "Control", "Alt", "Meta"].indexOf(key) > -1){
         CapybaraInvocation.namedKeydown(key);
         this.keyModifiersStack[this.keyModifiersStack.length-1].push(keys);
@@ -490,7 +490,7 @@ Capybara = {
         arg[_j] = this.wrapResult(arg[_j]);
       }
     } else if (arg && arg.nodeType == 1 && arg.tagName) {
-      return {'element-581e-422e-8be1-884c4e116226': this.registerNode(arg) }
+      return {'element-581e-422e-8be1-884c4e116226': this.registerNode(arg)};
     } else if (arg === null) {
       return undefined;
     } else if ( typeof arg == 'object' ) {


### PR DESCRIPTION
This includes 3 previous PRs and Updates support and gemspec to allow Capybara 2.13
* Supports all of the Capybara specified keys, except for :separator, with send_keys.
* Supports returning elements from evaluate_script
* Fixes calling within_frame with the same frame twice in a row
