### PR TITLE
Threadsafe mode support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.0)
+    addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     appraisal (0.4.1)
       bundler
@@ -30,13 +30,13 @@ GEM
       addressable (~> 2.3)
       spoon (~> 0.0.1)
     mime-types (2.99.3)
-    mini_magick (4.6.1)
-    mini_portile2 (2.1.0)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
-    nokogiri (1.7.1-java)
-    nokogiri (1.7.1-x86-mingw32)
-      mini_portile2 (~> 2.1.0)
+    mini_magick (4.7.0)
+    mini_portile (0.6.2)
+    nokogiri (1.6.6.4)
+      mini_portile (~> 0.6.0)
+    nokogiri (1.6.6.4-java)
+    nokogiri (1.6.6.4-x86-mingw32)
+      mini_portile (~> 0.6.0)
     public_suffix (2.0.5)
     rack (1.6.5)
     rack-protection (1.5.3)
@@ -84,4 +84,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/capybara-webkit.gemspec
+++ b/capybara-webkit.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.requirements << "Qt >= 4.8"
 
-  s.add_runtime_dependency("capybara", ">= 2.3.0", "< 2.14.0")
+  s.add_runtime_dependency("capybara", ">= 2.3.0", "< 2.15.0")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("rspec", "~> 3.5")

--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -359,7 +359,11 @@ module Capybara::Webkit
     end
 
     def default_wait_time
-      Capybara.respond_to?(:default_max_wait_time) ? Capybara.default_max_wait_time : Capybara.default_wait_time
+      if respond_to?(:session_options) && session_options
+        session_options.default_max_wait_time
+      else
+        Capybara.respond_to?(:default_max_wait_time) ? Capybara.default_max_wait_time : Capybara.default_wait_time
+      end
     end
 
     def find_modal(type, id, options)

--- a/lib/capybara/webkit/node.rb
+++ b/lib/capybara/webkit/node.rb
@@ -1,7 +1,7 @@
 module Capybara::Webkit
   class Node < Capybara::Driver::Node
-    def initialize(session, base, browser)
-      super(session, base)
+    def initialize(driver, base, browser)
+      super(driver, base)
       @browser = browser
     end
 
@@ -147,7 +147,7 @@ module Capybara::Webkit
     end
 
     def automatic_reload?
-      Capybara.respond_to?(:automatic_reload) && Capybara.automatic_reload
+      session_option(:automatic_reload)
     end
 
     def attached?
@@ -163,6 +163,14 @@ module Capybara::Webkit
     end
 
     private
+
+    def session_option(name)
+      if driver.respond_to?(:session_options)
+        driver.session_options.public_send(name)
+      else
+        Capybara.respond_to?(name) && Capybara.public_send(name)
+      end
+    end
 
     def convert_to_named_keys(key)
       if key.is_a? Array


### PR DESCRIPTION
This makes capybara-webkit compatible with the upcoming Capybara threadsafe/per-session config mode in Capybara 2.14 (to be released in the next few days)