### PR TITLE
Use Markdown headers to enable anchor links

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-New for 1.14.0:
+## 1.14.0
 
 * Fix the 'Reset' command in debug builds (on Windows)
 * Check for Windows platform in a jruby compatible way
@@ -8,27 +8,27 @@ New for 1.14.0:
 * Support most of the keys specified by Capybara for Node#send_keys
 * Fix issue with switching to the same frame twice in a row
 
-New for 1.13.0:
+## 1.13.0
 
 * Allow JavaScript errors to be raised as Ruby exceptions
 (`config.raise_javascript_errors` option)
 
-New for 1.12.0:
+## 1.12.0
 
 * Capybara 2.11 compatibility
 
-New for 1.11.1:
+## 1.11.1
 
 * Fix compiling on OS X with Qt 4.8
 
-New for 1.11.0:
+## 1.11.0
 
 * Pass default Server to Connection when not user provided
 * Support :backspace in Node#send_keys
 * Allow Qt 5.6 with QtWebKit module
 * Fix checkbox/radio screenshots on OS X using Fusion style
 
-New for 1.10.0:
+## 1.10.0
 
 * Capybara 2.7 compatibility
 * Extract class for booting the server
@@ -37,26 +37,26 @@ New for 1.10.0:
 * Abort requests before changing settings
 * Convert JavaScript DateTime objects to Ruby Date objects on evaluation
 
-New for 1.9.0:
+## 1.9.0
 
 * Raise error for Qt version greater than 5.5
 * Fix hovering SVG elements
 * Add basic send_keys implementation
 
-New for 1.8.0:
+## 1.8.0
 
 * Allow Capybara 2.6
 
-New for 1.7.1:
+## 1.7.1
 
 * Fix deprecation messages relating to default_wait_time
 
-New for 1.7.0:
+## 1.7.0
 
 * Capybara 2.5 compatibility (except Node#send_keys)
 * Update UnknownUrlHandler warning to use non-deprecated methods
 
-New for 1.6.0:
+## 1.6.0
 
 * New, easier, global configuration API.
 * Add `page.driver.allow_unknown_urls` to silent all unknown host warnings.
@@ -68,52 +68,52 @@ New for 1.6.0:
 * Deprecated `driver.browser`
 * Provide better behavior and information when the driver crashes
 
-New for 1.5.2:
+## 1.5.2
 
 * Fixes bug where aborted Ajax requests caused a crash during reset.
 
-New for 1.5.1:
+## 1.5.1
 
 * Fixes bug where Ajax requests would continue after a reset, causing native
   alerts to appear for some users and crashes for others.
 
-New for 1.5.0:
+## 1.5.0
 
 * Fixes for OpenBSD
 * Disable web page and object memory cache
 
-New for 1.4.1:
+## 1.4.1
 
 * Do not consider data URIs unknown.
 * Make sure webkit_server process runs in background.
 
-New for 1.4.0:
+## 1.4.0
 
 * Fix returning invisible text on a hidden page
 * Expose INCLUDEPATH and LIBS qmake variables
 * Drop support for older Capybara versions
 * Introduce allowed, blocked URL filters
 
-New for 1.3.1:
+## 1.3.1
 
 * Inherit from Capybara::Driver::Base for Capybara 2.4.4 compatibility.
 * Fix a bug in the modal API which could cause an incorrect modal to be found.
 
-New for 1.3.0:
+## 1.3.0
 
 * Capybara 2.4 compatibility.
 * Raise better errors if server fails to start
 * Offline application cache support.
 * Wildcard URL blacklist support.
 
-New for 1.2.0:
+## 1.2.0
 * Capybara 2.3 compatibility.
 * Kill webkit_server when parent process closes stdin.
 
-New for 1.1.1:
+## 1.1.1
 * Lock capybara dependency to < 2.2.0.
 
-New for 1.1.0:
+## 1.1.0
 
 * Improve messages for ClickFailed errors to aid debugging.
 * Fix long load times on Ruby 2.0.0-p195.
@@ -125,7 +125,7 @@ New for 1.1.0:
 * Fail immediately when trying to install with unsupported versions of Qt.
 * Fix race condition leading to InvalidResponseErrors.
 
-New for 1.0.0:
+## 1.0.0
 
 * Fix a memory leak in the logger.
 * Add Vagrant configuration.
@@ -140,13 +140,13 @@ New for 1.0.0:
 * Set text fields using native key events.
 * Clear localStorage on reset.
 
-New for 0.14.1:
+## 0.14.1
 
 * Rescue from Errno::ESRCH in the exit hook in case webkit_server has already ended.
 * Remove web font override for first-letter and first-line pseudo elements, which was causing issues for some users.
 * Restore viewport dimensions after rendering screenshots.
 
-New for 0.14.0:
+## 0.14.0
 
 * URL blacklist support.
 * Various fixes for JavaScript console messages.
@@ -165,7 +165,7 @@ New for 0.14.0:
 * Ensure queued commands start only after pending commands have finished.
 * Fix segfaults related to web fonts on OS X.
 
-New for 0.13.0:
+## 0.13.0
 
 * Better detect page load success, and better handle load failures.
 * HTTP Basic Auth support.
@@ -179,11 +179,11 @@ New for 0.13.0:
 * Performance improvements on Linux.
 * Support empty `multiple` attributes.
 
-New for 0.12.1:
+## 0.12.1
 
 * Fix integration with newer capybara for the debugging driver.
 
-New for 0.12.0:
+## 0.12.0
 * Better windows support
 * Support for localStorage
 * Added support for oninput event
@@ -194,25 +194,25 @@ New for 0.12.0:
 * Browser no longer tries to read empty responses (Fixes jruby issues).
 * Server will timeout if it can not start
 
-New for 0.11.0:
+## 0.11.0
 
 * Allow interaction with invisible elements
 * Use Timeout from stdlib since Capybara.timeout is being removed
 
-New for 0.10.1:
+## 0.10.1
 
 * LANG environment variable is set to en_US.UTF-8 in order to avoid string encoding issues from qmake.
 * pro, find_command, and CommandFactory are more structured.
 * Changed wiki link and directing platform specific issues to the google group.
 * Pass proper keycode value for keypress events.
 
-New for 0.10.0:
+## 0.10.0
 
 * current_url now more closely matches the behavior of Selenium
 * custom MAKE, QMAKE, and SPEC options can be set from the environment
 * BUG: Selected attribute is no longer removed when selecting/deselecting. Only the property is changed.
 
-New for 0.9.0:
+## 0.9.0
 
 * Raise an error when an invisible element receives #click.
 * Raise ElementNotDisplayedError for #drag_to and #select_option when element is invisible.


### PR DESCRIPTION
This way people can actually link to a specific version in the
changelog.

See: https://github.com/olivierlacan/capybara-webkit/blob/master/NEWS.md#1140

![image](https://cloud.githubusercontent.com/assets/65950/25927021/9337c958-35b8-11e7-87f8-2bad09b5d57d.png)
