### PR TITLE
Fix JRuby asynchronous close warning - Issue #944

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
       env: QMAKE=/usr/lib/x86_64-linux-gnu/qt4/bin/qmake
     - rvm: 2.3.3
       gemfile: gemfiles/master.gemfile
+    - rvm: jruby-9.1.8.0
+      gemfile: Gemfile
   allow_failures:
     - gemfile: gemfiles/master.gemfile
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       env: QMAKE=/usr/lib/x86_64-linux-gnu/qt4/bin/qmake
     - rvm: 2.3.3
       gemfile: gemfiles/master.gemfile
-    - rvm: jruby-9.1.8.0
+    - rvm: jruby-9.1.13.0
       gemfile: Gemfile
   allow_failures:
     - gemfile: gemfiles/master.gemfile

--- a/spec/fixtures/exit_text.rb
+++ b/spec/fixtures/exit_text.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+# require 'selenium-webdriver'
+
+RSpec.describe Capybara::Webkit::Driver do
+  it "should exit with a zero exit status" do
+    browser = Capybara::Webkit::Driver.new(TestApp).browser
+    expect(true).to eq(true)
+  end
+end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -25,6 +25,12 @@ describe Capybara::Webkit::Connection do
     end
   end
 
+  it "shouldn't output extraneous warnings when exiting", skip_on_windows: true do
+    output_str, status = Open3.capture2e("rspec spec/fixtures/exit_text.rb")
+    expect(status.exitstatus).to eq(0)
+    expect(output_str).not_to include("AsynchronousCloseException")
+  end
+
   it "raises an error if the server has stopped", skip_on_windows: true do
     path = "false"
     stub_const("Capybara::Webkit::Server::SERVER_PATH", path)


### PR DESCRIPTION
This brings back the explicit killing of the webkit_server process, so JRuby doesn't print an AsynchronousCloseException warning when shutting down.  The errors on the JRuby 1.9 builds are nothing to do with this change, and occur on master currently too -- not sure which gem update is causing those.