### PR TITLE
Limit JRuby-19mode test runs to rack < 2.0

### DIFF
--- a/gemfiles/2.13.gemfile
+++ b/gemfiles/2.13.gemfile
@@ -7,5 +7,6 @@ gem "json", "< 2.0", :platforms=>[:ruby_19, :jruby_19]
 gem "capybara", "~> 2.13.0"
 gem "addressable", "< 2.5.0", :platforms=>[:ruby_19, :jruby_19]
 gem "nokogiri", "< 1.7.0", :platforms=>[:ruby_19, :jruby_19]
+gem "rack", "<2.0", :platforms=>[:jruby_19]
 
 gemspec :path=>"../"

--- a/gemfiles/2.7.gemfile
+++ b/gemfiles/2.7.gemfile
@@ -8,5 +8,6 @@ gem "capybara", "~> 2.7.0"
 gem "rspec", "~> 2.14.0"
 gem "addressable", "< 2.5.0", :platforms=>[:ruby_19, :jruby_19]
 gem "nokogiri", "< 1.7.0", :platforms=>[:ruby_19, :jruby_19]
+gem "rack", "<2.0", :platforms=>[:jruby_19]
 
 gemspec :path=>"../"


### PR DESCRIPTION
rack 2+ is not compatible with JRuby-19mode which is causing failures on test runs.