### PR TITLE
Work around form fields overriding form element methods - Issue #1010

### DIFF
--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -337,6 +337,33 @@ describe Capybara::Session do
     end
   end
 
+  context "text" do
+    before(:all) do
+      @app = Class.new(ExampleApp) do
+        get "/" do
+          <<-HTML
+            <!DOCTYPE html>
+            <html>
+            <head></head>
+            <body>
+              <form>
+                This is my form
+                <input name="type"/>
+                <input name="tagName"/>
+              </form>
+            </body>
+            </html>
+          HTML
+        end
+      end
+    end
+
+    it "gets a forms text when inputs have conflicting names" do
+      subject.visit("/")
+      expect(subject.find(:css, "form").text).to eq("This is my form")
+    end
+  end
+
   context 'click tests' do
     before(:all) do
       @app = Class.new(ExampleApp) do

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -66,7 +66,8 @@ Capybara = {
 
   text: function (index) {
     var node = this.getNode(index);
-    var type = (node.type || node.tagName).toLowerCase();
+    var type = node instanceof HTMLFormElement ? 'form' : (node.type || node.tagName).toLowerCase();
+
     if (!this.isNodeVisible(node)) {
       return '';
     } else if (type == "textarea") {


### PR DESCRIPTION
This fixes the basic problem in issue #1010 of a field element with name "type" causing `#text` to crash if called on the associated form element.