### PR TITLE
Create new object when wrapping objects - Issue #1028

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -557,6 +557,13 @@ describe Capybara::Webkit::Driver do
       expect(result).to eq 'one' => 1
     end
 
+    it "evaluate Javascript and returns an object when the original was readonly" do
+      result = driver.evaluate_script(%<window.getComputedStyle(document.getElementById('greeting'))>)
+      # result = driver.evaluate_script(%<document.getElementById('greeting')>)
+      expect(result).to be_a Hash
+      expect(result["zIndex"]).to eq "auto"
+    end
+
     it "evaluates Javascript and returns true" do
       result = driver.evaluate_script(%<true>)
       expect(result).to be true

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -496,12 +496,16 @@ Capybara = {
       return {'element-581e-422e-8be1-884c4e116226': this.registerNode(arg)};
     } else if (arg === null) {
       return undefined;
+    } else if (arg instanceof Date){
+      return arg;
     } else if ( typeof arg == 'object' ) {
       this._visitedObjects.push(arg);
+      var result = {};
       for(var _k in arg){
-        arg[_k] = this.wrapResult(arg[_k]);
+        result[_k] = this.wrapResult(arg[_k]);
       }
       this._visitedObjects.pop();
+      return result;
     }
     return arg;
   }


### PR DESCRIPTION
When wrapping results, it's possible objects are readonly so copy instead of assigning back to the original object.  Fixes Issue #1028