### PR TITLE
Only override font in Qt versions where it's needed

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -2069,14 +2069,17 @@ describe Capybara::Webkit::Driver do
     end
 
     it "ignores custom fonts" do
+      skip "font replacement not needed for QT >= 5" unless driver.version =~ /Qt: 4/
       expect(font_family).to eq "Arial"
     end
 
     it "ignores custom fonts before an element" do
+      skip "font replacement not needed for QT >= 5" unless driver.version =~ /Qt: 4/
       expect(font_family).to eq "Arial"
     end
 
     it "ignores custom fonts after an element" do
+      skip "font replacement not needed for QT >= 5" unless driver.version =~ /Qt: 4/
       expect(font_family).to eq "Arial"
     end
   end

--- a/src/WebPage.cpp
+++ b/src/WebPage.cpp
@@ -25,7 +25,10 @@ WebPage::WebPage(WebPageManager *manager, QObject *parent) : QWebPage(parent) {
 
   setForwardUnsupportedContent(true);
   loadJavascript();
-  setUserStylesheet();
+
+  #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+    setUserStylesheet();
+  #endif
 
   this->setCustomNetworkAccessManager();
 


### PR DESCRIPTION
This fix was only needed for Qt < 5.  It has caused issues for users with custom fonts when using characters which have no matching codepoint in the Arial font.  This PR only applies the font override to versions of Qt where needed.  As mentioned in Issue #1006 the number of users still on Qt < 5 should be relatively small, and it makes no sense to penalize users on Qt >= 5