### PR TITLE
Node#[] should prefer properties over attributes

### DIFF
--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -1439,7 +1439,7 @@ describe Capybara::Webkit::Driver do
       end
 
       it "does not modify the selected attribute of a new selection" do
-        expect(monkey_option['selected']).to be_nil
+        expect(driver.evaluate_script("arguments[0].getAttribute('selected')", monkey_option)).to be_nil
       end
 
       it "returns the old value when a reset button is clicked" do

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -1,0 +1,66 @@
+# -*- encoding: UTF-8 -*-
+
+require "spec_helper"
+require "capybara/webkit/driver"
+require "base64"
+require "self_signed_ssl_cert"
+
+describe Capybara::Webkit::Node do
+  include AppRunner
+
+  def visit(path, driver = self.driver)
+    driver.visit(url(path))
+  end
+
+  def url(path)
+    "#{AppRunner.app_host}#{path}"
+  end
+
+  context "html app" do
+    let(:driver) do
+      driver_for_html(<<-HTML)
+        <html>
+          <head>
+            <title>Hello HTML</title>
+          </head>
+          <body>
+            <form action="/" method="GET">
+              <input type="text" name="foo" value="bar"/>
+              <input type="checkbox" name="checkedbox" value="1" checked="checked"/>
+              <input type="checkbox" name="uncheckedbox" value="2"/>
+              <input type="checkbox" name="falsecheckedbox" value="3" checked="false"/>
+              <input type="text" name="styled" style="font-size: 150%;"/>
+            </form>
+          </body>
+        </html>
+      HTML
+    end
+
+    before { visit("/") }
+
+    context "Node#[]" do
+      it "gets boolean properties" do
+        box1 = driver.find_css('input[name="checkedbox"]').first
+        box2 = driver.find_css('input[name="uncheckedbox"]').first
+        box3 = driver.find_css('input[name="falsecheckedbox"]').first
+        expect(box1["checked"]).to eq true
+        expect(box2["checked"]).to eq false
+        expect(box3["checked"]).to eq true
+        box1.set(false)
+        expect(box1["checked"]).to eq false
+      end
+
+      it "prefers property over attribute" do
+        input = driver.find_css('input[name="foo"]').first
+        expect(input["value"]).to eq "bar"
+        input.set("new value")
+        expect(input["value"]).to eq "new value"
+      end
+
+      it "returns attribute when property is an object" do
+        input = driver.find_css('input[name="styled"]').first
+        expect(input["style"]).to eq "font-size: 150%;"
+      end
+    end
+  end
+end

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -1,6 +1,7 @@
 #include "Node.h"
 #include "WebPage.h"
 #include "WebPageManager.h"
+#include "JsonSerializer.h"
 #include "InvocationResult.h"
 
 Node::Node(WebPageManager *manager, QStringList &arguments, QObject *parent) : JavascriptCommand(manager, arguments, parent) {
@@ -14,7 +15,14 @@ void Node::start() {
   if (functionName == "focus_frame") {
     page()->setCurrentFrameParent(page()->currentFrame()->parentFrame());
   }
-  finish(&result);
+
+  if (result.hasError()) {
+    finish(&result);
+  } else {
+    JsonSerializer serializer;
+    InvocationResult jsonResult = InvocationResult(serializer.serialize(result.result()));
+    finish(&jsonResult);
+  }
 }
 
 QString Node::toString() const {

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -85,22 +85,15 @@ Capybara = {
 
   attribute: function (index, name) {
     var node = this.getNode(index);
-    switch(name) {
-    case 'checked':
-      return node.checked;
-      break;
-
-    case 'disabled':
-      return node.disabled;
-      break;
-
-    case 'multiple':
-      return node.multiple;
-      break;
-
-    default:
+    if (node.hasAttribute(name)) {
       return node.getAttribute(name);
     }
+    return void 0;
+  },
+
+  property: function (index, name) {
+    var node = this.getNode(index);
+    return node[name];
   },
 
   hasAttribute: function(index, name) {


### PR DESCRIPTION
This changes Node#[] to match the behavior of other drivers in preferring properties over attributes.    It also changes the `Node` command to JSON encode the return so we can differentiate between boolean responses and strings. Fixes issue #914 