### PR TITLE
Deprecate the Node#attached? method

### DIFF
--- a/lib/capybara/webkit/node.rb
+++ b/lib/capybara/webkit/node.rb
@@ -151,6 +151,8 @@ module Capybara::Webkit
     end
 
     def attached?
+      warn "[DEPRECATION] The Capybara::Webkit::Node#attached? " \
+        "method is deprecated without replacement."
       @browser.command("Node", "isAttached", native) == "true"
     end
 


### PR DESCRIPTION
Deprecate an unused method