### PR TITLE
Add support for keys and offset with mouse clicks coming in Capybara 3

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -6,4 +6,5 @@ end
 
 appraise "master" do
   gem "capybara", github: "jnicklas/capybara"
+  gem "puma"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     capybara-webkit (1.14.0)
-      capybara (~> 2.3)
+      capybara (>= 2.3, < 4.0)
       json
 
 GEM
@@ -14,13 +14,13 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    capybara (2.15.4)
+    capybara (2.17.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      xpath (~> 2.0)
+      xpath (>= 2.0, < 4.0)
     diff-lcs (1.3)
     ffi (1.9.18-java)
     json (1.8.6)
@@ -36,14 +36,11 @@ GEM
     mustermann (1.0.1)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    nokogiri (1.8.1-java)
-    nokogiri (1.8.1-x86-mingw32)
-      mini_portile2 (~> 2.3.0)
     public_suffix (3.0.0)
     rack (2.0.3)
     rack-protection (2.0.0)
       rack
-    rack-test (0.7.0)
+    rack-test (0.8.2)
       rack (>= 1.0, < 3)
     rake (11.3.0)
     rspec (3.7.0)
@@ -68,8 +65,8 @@ GEM
       ffi
     thor (0.20.0)
     tilt (2.0.8)
-    xpath (2.1.0)
-      nokogiri (~> 1.3)
+    xpath (3.0.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   java

--- a/capybara-webkit.gemspec
+++ b/capybara-webkit.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.requirements << "Qt >= 4.8"
 
-  s.add_runtime_dependency("capybara", "~>2.3")
+  s.add_runtime_dependency("capybara", ">= 2.3", "< 4.0")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("rspec", "~> 3.5")

--- a/gemfiles/master.gemfile
+++ b/gemfiles/master.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "json", "< 2.0", platforms: [:ruby_19, :jruby_19]
 gem "capybara", github: "jnicklas/capybara"
+gem "puma"
 
 gemspec path: "../"

--- a/lib/capybara/webkit/node.rb
+++ b/lib/capybara/webkit/node.rb
@@ -68,16 +68,16 @@ module Capybara::Webkit
       end
     end
 
-    def click
-      invoke("leftClick")
+    def click(keys = [], offset = {})
+      invoke("leftClick", keys.to_json, offset.to_json)
     end
 
-    def double_click
-      invoke("doubleClick")
+    def double_click(keys = [], offset = {})
+      invoke("doubleClick", keys.to_json, offset.to_json)
     end
 
-    def right_click
-      invoke("rightClick")
+    def right_click(keys = [], offset = {})
+      invoke("rightClick", keys.to_json, offset.to_json)
     end
 
     def hover

--- a/lib/capybara/webkit/node.rb
+++ b/lib/capybara/webkit/node.rb
@@ -45,7 +45,8 @@ module Capybara::Webkit
       invoke 'setInnerHTML', value
     end
 
-    def set(value)
+    def set(value, options = {})
+      warn "Options passed to Node#set but capybara-webkit doesn't currently support any - ignoring" unless options.empty?
       invoke "set", *[value].flatten
     end
 

--- a/src/JavascriptInvocation.h
+++ b/src/JavascriptInvocation.h
@@ -20,9 +20,9 @@ class JavascriptInvocation : public QObject {
     QString &functionName();
     bool allowUnattached();
     QStringList &arguments();
-    Q_INVOKABLE void leftClick(int x, int y);
-    Q_INVOKABLE void rightClick(int x, int y);
-    Q_INVOKABLE void doubleClick(int x, int y);
+    Q_INVOKABLE void leftClick(int x, int y, QVariantList keys);
+    Q_INVOKABLE void rightClick(int x, int y, QVariantList keys);
+    Q_INVOKABLE void doubleClick(int x, int y, QVariantList keys);
     Q_INVOKABLE bool clickTest(QWebElement element, int absoluteX, int absoluteY);
     Q_INVOKABLE QVariantMap clickPosition(QWebElement element, int left, int top, int width, int height);
     Q_INVOKABLE void hover(int absoluteX, int absoluteY);
@@ -46,5 +46,8 @@ class JavascriptInvocation : public QObject {
     int keyCodeForName(const QString &);
     Qt::Key key_enum;
     Qt::KeyboardModifiers m_currentModifiers;
+    Qt::KeyboardModifiers modifiers(const QVariantList& keys);
+    static QMap<QString, Qt::KeyboardModifiers> makeModifiersMap();
+    static QMap<QString, Qt::KeyboardModifiers> m_modifiersMap;
 };
 

--- a/src/WebPage.cpp
+++ b/src/WebPage.cpp
@@ -275,9 +275,9 @@ QString WebPage::failureString() {
     return message + m_errorPageMessage;
 }
 
-void WebPage::mouseEvent(QEvent::Type type, const QPoint &position, Qt::MouseButton button) {
+void WebPage::mouseEvent(QEvent::Type type, const QPoint &position, Qt::MouseButton button, Qt::KeyboardModifiers modifiers) {
   m_mousePosition = position;
-  QMouseEvent event(type, position, button, button, Qt::NoModifier);
+  QMouseEvent event(type, position, button, button, modifiers);
   QApplication::sendEvent(this, &event);
 }
 
@@ -491,5 +491,3 @@ QWebFrame* WebPage::currentFrameParent() {
 void WebPage::setCurrentFrameParent(QWebFrame* frame) {
   m_currentFrameParent = frame;
 }
-
-

--- a/src/WebPage.h
+++ b/src/WebPage.h
@@ -50,7 +50,7 @@ class WebPage : public QWebPage {
     QVariantMap pageHeaders();
     QByteArray body();
     QString contentType();
-    void mouseEvent(QEvent::Type type, const QPoint &position, Qt::MouseButton button);
+    void mouseEvent(QEvent::Type type, const QPoint &position, Qt::MouseButton button, Qt::KeyboardModifiers modifiers = Qt::NoModifier);
     bool clickTest(QWebElement element, int absoluteX, int absoluteY);
     void resize(int, int);
     int modalCount();

--- a/src/capybara.js
+++ b/src/capybara.js
@@ -7,7 +7,15 @@ Capybara = {
   invoke: function () {
     try {
       if (CapybaraInvocation.functionName == "leftClick") {
-        return this["verifiedClickPosition"].apply(this, CapybaraInvocation.arguments);
+        var args = CapybaraInvocation.arguments;
+        var leftClickOptions = this["verifiedClickPosition"].apply(this, args);
+        leftClickOptions["keys"] = JSON.parse(args[1]);
+        offset = JSON.parse(args[2]);
+        if (offset && offset.x && offset.y){
+          leftClickOptions["absoluteX"] = leftClickOptions["absoluteLeft"] + offset.x;
+          leftClickOptions["absoluteY"] = leftClickOptions["absoluteTop"] + offset.y;
+        }
+        return leftClickOptions;
       } else {
         return this[CapybaraInvocation.functionName].apply(this, CapybaraInvocation.arguments);
       }
@@ -208,22 +216,28 @@ Capybara = {
     return pos;
   },
 
-  click: function (index, action) {
+  click: function (index, action, keys, offset) {
     var pos = this.verifiedClickPosition(index);
-    action(pos.absoluteX, pos.absoluteY);
+    keys = keys ? JSON.parse(keys) : [];
+    offset = offset ? JSON.parse(offset) : {};
+    if (offset && (offset.x != null) && (offset.y != null)){
+      action(pos.absoluteLeft + offset.x, pos.absoluteTop + offset.y, keys);
+    } else {
+      action(pos.absoluteX, pos.absoluteY, keys);
+    }
   },
 
-  leftClick: function (index) {
-    this.click(index, CapybaraInvocation.leftClick);
+  leftClick: function (index, keys, offset) {
+    this.click(index, CapybaraInvocation.leftClick, keys, offset);
   },
 
-  doubleClick: function(index) {
-    this.click(index, CapybaraInvocation.leftClick);
-    this.click(index, CapybaraInvocation.doubleClick);
+  doubleClick: function(index, keys, offset) {
+    this.click(index, CapybaraInvocation.leftClick, keys, offset);
+    this.click(index, CapybaraInvocation.doubleClick, keys, offset);
   },
 
-  rightClick: function(index) {
-    this.click(index, CapybaraInvocation.rightClick);
+  rightClick: function(index, keys, offset) {
+    this.click(index, CapybaraInvocation.rightClick, keys, offset);
   },
 
   hover: function (index) {


### PR DESCRIPTION
This adds support for passing key modifiers and offset x,y coordinates to be set when calling `Node#click`/`right_click`/`double_click` coming in Capybara 3