### PR TITLE
Puma is required to run the Capybara 3 tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 gem "json", "< 2.0", :platforms=>[:ruby_19, :jruby_19]
+gem 'puma'


### PR DESCRIPTION
Add puma to the Gemfile since it's a requirement for running Capybara 3 tests.