### PR TITLE
Retry crash failure on reset!

### DIFF
--- a/lib/capybara/webkit/driver.rb
+++ b/lib/capybara/webkit/driver.rb
@@ -307,8 +307,13 @@ module Capybara::Webkit
     end
 
     def reset!
+      tries ||= 2
       @browser.reset!
       apply_options
+    rescue Capybara::Webkit::CrashError
+      tries -= 1
+      retry unless tries.zero?
+      raise
     end
 
     def has_shortcircuit_timeout?


### PR DESCRIPTION
If a crash occurs during `reset!`, options such as `allowed_urls`, `blocked_urls`, etc aren't correctly set for the next test.  This adds a retry to `reset!` in an attempt to work around the crashes.