### PR TITLE
[Bug fix] Support `:numpad8` for `send_keys` method

### DIFF
--- a/lib/capybara/webkit/node.rb
+++ b/lib/capybara/webkit/node.rb
@@ -214,7 +214,7 @@ module Capybara::Webkit
         when :page_down
           { "key" => "PageDown" }
         when :numpad0, :numpad1, :numpad2, :numpad3, :numpad4,
-             :numpad5, :numpad6, :numpad7, :numpad9, :numpad9
+             :numpad5, :numpad6, :numpad7, :numpad8, :numpad9
           { "key" => key[-1], "modifier" => "keypad" }
         when :multiply
           { "key" => "Asterisk", "modifier" => "keypad" }

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -1430,6 +1430,13 @@ describe Capybara::Webkit::Driver do
         expect(input.value).to eq "UPPER"
       end
 
+      it "should support :numpad[0-9]" do
+        input = driver.find_xpath("//input").first
+        input.send_keys(:numpad0, :numpad1, :numpad2, :numpad3, :numpad4,
+                        :numpad5, :numpad6, :numpad7, :numpad8, :numpad9)
+        expect(input.value).to eq "0123456789"
+      end
+
       it "releases modifiers correctly" do
         input = driver.find_xpath("//input").first
         input.send_keys("a", [:shift, :left], "a")


### PR DESCRIPTION
`:numpad9` is duplicated instead of `:numpad8`, so `send_keys` method raises an error when it receives `:numpad8`.
We can reproduce this behaviour with the added test case.

This pull request fixes the problem.

Note
===

I found this bug with `RUBYOPT=-w`.  For example: (The second warning)

```
$ ruby -Ilib -rcapybara-webkit -e ''
/path/to/lib/ruby/gems/2.6.0/gems/addressable-2.5.2/lib/addressable/idna/pure.rb:154: warning: assigned but unused variable - startercc
/path/to/lib/capybara/webkit/node.rb:217: warning: duplicated when clause is ignored
```